### PR TITLE
feat(indexing): add optional Goldsky subgraph fallback

### DIFF
--- a/docs/final/ENVIRONMENT_GUIDE.md
+++ b/docs/final/ENVIRONMENT_GUIDE.md
@@ -41,6 +41,7 @@ Copy from `frontend/.env.local.example` if it exists, or create manually:
 # frontend/.env.local
 
 NEXT_PUBLIC_SUBGRAPH_URL=https://api.studio.thegraph.com/query/1748590/arcnslatest/v3
+NEXT_PUBLIC_GOLDSKY_SUBGRAPH_URL=
 NEXT_PUBLIC_RPC_URL=https://rpc.testnet.arc.network
 NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=<your_project_id>
 ```
@@ -48,6 +49,7 @@ NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=<your_project_id>
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `NEXT_PUBLIC_SUBGRAPH_URL` | Yes | The Graph Studio query URL for `arcnslatest`. Used for portfolio, history, and reverse resolution. |
+| `NEXT_PUBLIC_GOLDSKY_SUBGRAPH_URL` | Optional | Goldsky fallback subgraph URL for ArcNS indexed reads on Arc Testnet. Queried only if the primary subgraph endpoint fails or returns unusable data. |
 | `NEXT_PUBLIC_RPC_URL` | Yes | Arc Testnet RPC endpoint. Used as fallback when subgraph is unavailable. |
 | `NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID` | Yes | WalletConnect v2 project ID. Get from https://cloud.walletconnect.com |
 
@@ -56,6 +58,7 @@ NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=<your_project_id>
 - `frontend/.env.local` is in `.gitignore`. Never commit it.
 - Contract addresses are **not** in `.env.local`. They are generated into `frontend/src/lib/generated-contracts.ts` by `scripts/generate-frontend-config.js`. Do not hand-edit `generated-contracts.ts`.
 - If the subgraph URL changes (e.g. after a new subgraph version is deployed), update `NEXT_PUBLIC_SUBGRAPH_URL` and restart the dev server or redeploy.
+- Keep `NEXT_PUBLIC_SUBGRAPH_URL` as the primary endpoint. `NEXT_PUBLIC_GOLDSKY_SUBGRAPH_URL` is optional fallback only.
 
 ---
 

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -24,3 +24,7 @@ NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=your_project_id_here
 # arcnslatest — v3 canonical subgraph on Arc testnet.
 # Get the query URL from The Graph Studio dashboard after deploying.
 NEXT_PUBLIC_SUBGRAPH_URL=https://api.studio.thegraph.com/query/YOUR_ID/arcnslatest/v3
+
+# Optional Goldsky fallback for ArcNS indexed data on Arc Testnet.
+# Keep NEXT_PUBLIC_SUBGRAPH_URL as the primary endpoint.
+NEXT_PUBLIC_GOLDSKY_SUBGRAPH_URL=

--- a/frontend/src/lib/graphql.ts
+++ b/frontend/src/lib/graphql.ts
@@ -10,18 +10,23 @@
  * are NOT touched here — this file is read-only indexed data only.
  */
 
-const SUBGRAPH_URL = process.env.NEXT_PUBLIC_SUBGRAPH_URL || "";
+const PRIMARY_SUBGRAPH_URL = process.env.NEXT_PUBLIC_SUBGRAPH_URL || "";
+const GOLDSKY_SUBGRAPH_URL = process.env.NEXT_PUBLIC_GOLDSKY_SUBGRAPH_URL || "";
 
-const SUBGRAPH_ENABLED =
-  Boolean(SUBGRAPH_URL) && !SUBGRAPH_URL.includes("YOUR_ID");
+function isConfiguredSubgraphUrl(url: string): boolean {
+  return Boolean(url) && !url.includes("YOUR_ID");
+}
 
-async function gqlQuery<T>(
+const PRIMARY_SUBGRAPH_ENABLED = isConfiguredSubgraphUrl(PRIMARY_SUBGRAPH_URL);
+const GOLDSKY_SUBGRAPH_ENABLED = isConfiguredSubgraphUrl(GOLDSKY_SUBGRAPH_URL);
+
+async function gqlQueryFromUrl<T>(
+  url: string,
   query: string,
   variables?: Record<string, unknown>
 ): Promise<T | null> {
-  if (!SUBGRAPH_ENABLED) return null;
   try {
-    const res = await fetch(SUBGRAPH_URL, {
+    const res = await fetch(url, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ query, variables }),
@@ -34,6 +39,25 @@ async function gqlQuery<T>(
   } catch {
     return null;
   }
+}
+
+async function gqlQuery<T>(
+  query: string,
+  variables?: Record<string, unknown>
+): Promise<T | null> {
+  if (!PRIMARY_SUBGRAPH_ENABLED && !GOLDSKY_SUBGRAPH_ENABLED) return null;
+
+  // Goldsky is an optional fallback endpoint for ArcNS indexed data on Arc Testnet.
+  if (PRIMARY_SUBGRAPH_ENABLED) {
+    const primaryData = await gqlQueryFromUrl<T>(PRIMARY_SUBGRAPH_URL, query, variables);
+    if (primaryData !== null) return primaryData;
+  }
+
+  if (GOLDSKY_SUBGRAPH_ENABLED) {
+    return await gqlQueryFromUrl<T>(GOLDSKY_SUBGRAPH_URL, query, variables);
+  }
+
+  return null;
 }
 
 // ─── Types ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds optional Goldsky subgraph fallback support for ArcNS indexed reads.

The current primary subgraph endpoint remains unchanged via `NEXT_PUBLIC_SUBGRAPH_URL`. Goldsky is only used as a fallback when `NEXT_PUBLIC_GOLDSKY_SUBGRAPH_URL` is configured and the primary indexed read fails or returns unusable data.

Existing RPC fallback behavior is preserved.

## Why

ArcNS now has a parallel Goldsky product subgraph deployed on Arc Testnet:

`arcns-product/v0.1.0`

Goldsky status:
- healthy / Active
- 100% synced
- chain: `arc-testnet`

Parity checks passed for:
- `flowpay.arc`
- `thebstoftimes.arc`
- `bob.arc`
- `dnyelfy.circle`

The `thebstoftimes.arc` no-address proof point is preserved: registered/active with owner + expiry, but no receiving address set.

## Changes

- Adds optional `NEXT_PUBLIC_GOLDSKY_SUBGRAPH_URL`
- Keeps `NEXT_PUBLIC_SUBGRAPH_URL` as primary
- Tries primary indexed read first
- Falls back to Goldsky if configured
- Returns `null` if both indexed endpoints fail, preserving existing RPC fallback
- Documents the optional env var in:
  - `frontend/.env.local.example`
  - `docs/final/ENVIRONMENT_GUIDE.md`

## Safety

- No contract changes
- No deployment script changes
- No package/lockfile changes
- No production endpoint switch
- No Vercel env changes
- No RPC fallback removal
- Default behavior remains unchanged when `NEXT_PUBLIC_GOLDSKY_SUBGRAPH_URL` is unset

## Validation

- `npm --prefix frontend run lint` passed with existing warnings only
- `npm --prefix frontend run build` passed