### PR TITLE
feat(indexing): support configurable subgraph fallback

### DIFF
--- a/docs/final/ENVIRONMENT_GUIDE.md
+++ b/docs/final/ENVIRONMENT_GUIDE.md
@@ -40,7 +40,8 @@ Copy from `frontend/.env.local.example` if it exists, or create manually:
 ```bash
 # frontend/.env.local
 
-NEXT_PUBLIC_SUBGRAPH_URL=https://api.studio.thegraph.com/query/1748590/arcnslatest/v3
+NEXT_PUBLIC_SUBGRAPH_URL=https://api.goldsky.com/api/public/project_cmpn4idciwist01th4uejh86p/subgraphs/arcns-product/v0.1.0/gn
+NEXT_PUBLIC_SUBGRAPH_FALLBACK_URL=https://api.studio.thegraph.com/query/1748590/arcnslatest/v3
 NEXT_PUBLIC_GOLDSKY_SUBGRAPH_URL=
 NEXT_PUBLIC_RPC_URL=https://rpc.testnet.arc.network
 NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=<your_project_id>
@@ -48,8 +49,9 @@ NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=<your_project_id>
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `NEXT_PUBLIC_SUBGRAPH_URL` | Yes | The Graph Studio query URL for `arcnslatest`. Used for portfolio, history, and reverse resolution. |
-| `NEXT_PUBLIC_GOLDSKY_SUBGRAPH_URL` | Optional | Goldsky fallback subgraph URL for ArcNS indexed reads on Arc Testnet. Queried only if the primary subgraph endpoint fails or returns unusable data. |
+| `NEXT_PUBLIC_SUBGRAPH_URL` | Yes | Primary subgraph endpoint for indexed reads (portfolio, history, reverse resolution). Recommended production value: Goldsky product endpoint. |
+| `NEXT_PUBLIC_SUBGRAPH_FALLBACK_URL` | Optional | Generic fallback subgraph endpoint. Queried only if `NEXT_PUBLIC_SUBGRAPH_URL` fails or returns unusable data. Recommended production value: legacy The Graph Studio endpoint. |
+| `NEXT_PUBLIC_GOLDSKY_SUBGRAPH_URL` | Optional | Backward-compatible additional fallback endpoint. Queried after `NEXT_PUBLIC_SUBGRAPH_FALLBACK_URL` only when configured and different. |
 | `NEXT_PUBLIC_RPC_URL` | Yes | Arc Testnet RPC endpoint. Used as fallback when subgraph is unavailable. |
 | `NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID` | Yes | WalletConnect v2 project ID. Get from https://cloud.walletconnect.com |
 
@@ -58,7 +60,10 @@ NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=<your_project_id>
 - `frontend/.env.local` is in `.gitignore`. Never commit it.
 - Contract addresses are **not** in `.env.local`. They are generated into `frontend/src/lib/generated-contracts.ts` by `scripts/generate-frontend-config.js`. Do not hand-edit `generated-contracts.ts`.
 - If the subgraph URL changes (e.g. after a new subgraph version is deployed), update `NEXT_PUBLIC_SUBGRAPH_URL` and restart the dev server or redeploy.
-- Keep `NEXT_PUBLIC_SUBGRAPH_URL` as the primary endpoint. `NEXT_PUBLIC_GOLDSKY_SUBGRAPH_URL` is optional fallback only.
+- Keep `NEXT_PUBLIC_SUBGRAPH_URL` as the primary endpoint.
+- Use `NEXT_PUBLIC_SUBGRAPH_FALLBACK_URL` as the preferred generic fallback endpoint.
+- `NEXT_PUBLIC_GOLDSKY_SUBGRAPH_URL` remains optional for backward compatibility as an additional fallback.
+- RPC fallback behavior remains unchanged and is still used when indexed endpoints fail or return unusable data.
 
 ---
 
@@ -68,7 +73,8 @@ When deploying to Vercel, set the following environment variables in the Vercel 
 
 | Variable | Value |
 |----------|-------|
-| `NEXT_PUBLIC_SUBGRAPH_URL` | `https://api.studio.thegraph.com/query/1748590/arcnslatest/v3` |
+| `NEXT_PUBLIC_SUBGRAPH_URL` | `https://api.goldsky.com/api/public/project_cmpn4idciwist01th4uejh86p/subgraphs/arcns-product/v0.1.0/gn` |
+| `NEXT_PUBLIC_SUBGRAPH_FALLBACK_URL` | `https://api.studio.thegraph.com/query/1748590/arcnslatest/v3` |
 | `NEXT_PUBLIC_RPC_URL` | `https://rpc.testnet.arc.network` |
 | `NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID` | Your WalletConnect project ID |
 
@@ -84,9 +90,14 @@ The Graph Studio query URL format is:
 https://api.studio.thegraph.com/query/<STUDIO_ID>/arcnslatest/<VERSION>
 ```
 
-Current production URL:
+Legacy The Graph Studio URL:
 ```
 https://api.studio.thegraph.com/query/1748590/arcnslatest/v3
+```
+
+Recommended Goldsky primary URL:
+```
+https://api.goldsky.com/api/public/project_cmpn4idciwist01th4uejh86p/subgraphs/arcns-product/v0.1.0/gn
 ```
 
 After deploying a new subgraph version, update `NEXT_PUBLIC_SUBGRAPH_URL` to the new version URL. See [SUBGRAPH_GUIDE.md](SUBGRAPH_GUIDE.md) for the full subgraph deployment flow.

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -21,10 +21,14 @@ NEXT_PUBLIC_RPC_URL_3=https://rpc.quicknode.testnet.arc.network
 NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=your_project_id_here
 
 # ─── Subgraph ─────────────────────────────────────────────────────────────────
-# arcnslatest — v3 canonical subgraph on Arc testnet.
-# Get the query URL from The Graph Studio dashboard after deploying.
+# Primary indexed-data endpoint for frontend GraphQL reads.
+# Production recommendation: set this to your active Goldsky (or preferred) endpoint.
 NEXT_PUBLIC_SUBGRAPH_URL=https://api.studio.thegraph.com/query/YOUR_ID/arcnslatest/v3
 
-# Optional Goldsky fallback for ArcNS indexed data on Arc Testnet.
-# Keep NEXT_PUBLIC_SUBGRAPH_URL as the primary endpoint.
+# Optional generic subgraph fallback endpoint.
+# Queried only if NEXT_PUBLIC_SUBGRAPH_URL fails.
+NEXT_PUBLIC_SUBGRAPH_FALLBACK_URL=
+
+# Optional backward-compatible Goldsky fallback endpoint.
+# Used after NEXT_PUBLIC_SUBGRAPH_FALLBACK_URL when configured and different.
 NEXT_PUBLIC_GOLDSKY_SUBGRAPH_URL=

--- a/frontend/src/lib/graphql.ts
+++ b/frontend/src/lib/graphql.ts
@@ -11,6 +11,7 @@
  */
 
 const PRIMARY_SUBGRAPH_URL = process.env.NEXT_PUBLIC_SUBGRAPH_URL || "";
+const FALLBACK_SUBGRAPH_URL = process.env.NEXT_PUBLIC_SUBGRAPH_FALLBACK_URL || "";
 const GOLDSKY_SUBGRAPH_URL = process.env.NEXT_PUBLIC_GOLDSKY_SUBGRAPH_URL || "";
 
 function isConfiguredSubgraphUrl(url: string): boolean {
@@ -18,7 +19,33 @@ function isConfiguredSubgraphUrl(url: string): boolean {
 }
 
 const PRIMARY_SUBGRAPH_ENABLED = isConfiguredSubgraphUrl(PRIMARY_SUBGRAPH_URL);
+const FALLBACK_SUBGRAPH_ENABLED = isConfiguredSubgraphUrl(FALLBACK_SUBGRAPH_URL);
 const GOLDSKY_SUBGRAPH_ENABLED = isConfiguredSubgraphUrl(GOLDSKY_SUBGRAPH_URL);
+
+function normalizeSubgraphUrl(url: string): string {
+  return url.trim();
+}
+
+function getConfiguredSubgraphEndpoints(): string[] {
+  const orderedCandidates = [
+    PRIMARY_SUBGRAPH_ENABLED ? PRIMARY_SUBGRAPH_URL : "",
+    FALLBACK_SUBGRAPH_ENABLED ? FALLBACK_SUBGRAPH_URL : "",
+    GOLDSKY_SUBGRAPH_ENABLED ? GOLDSKY_SUBGRAPH_URL : "",
+  ];
+
+  const seen = new Set<string>();
+  const endpoints: string[] = [];
+
+  for (const candidate of orderedCandidates) {
+    if (!candidate) continue;
+    const normalized = normalizeSubgraphUrl(candidate);
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    endpoints.push(normalized);
+  }
+
+  return endpoints;
+}
 
 async function gqlQueryFromUrl<T>(
   url: string,
@@ -45,16 +72,12 @@ async function gqlQuery<T>(
   query: string,
   variables?: Record<string, unknown>
 ): Promise<T | null> {
-  if (!PRIMARY_SUBGRAPH_ENABLED && !GOLDSKY_SUBGRAPH_ENABLED) return null;
+  const endpoints = getConfiguredSubgraphEndpoints();
+  if (endpoints.length === 0) return null;
 
-  // Goldsky is an optional fallback endpoint for ArcNS indexed data on Arc Testnet.
-  if (PRIMARY_SUBGRAPH_ENABLED) {
-    const primaryData = await gqlQueryFromUrl<T>(PRIMARY_SUBGRAPH_URL, query, variables);
-    if (primaryData !== null) return primaryData;
-  }
-
-  if (GOLDSKY_SUBGRAPH_ENABLED) {
-    return await gqlQueryFromUrl<T>(GOLDSKY_SUBGRAPH_URL, query, variables);
+  for (const endpoint of endpoints) {
+    const data = await gqlQueryFromUrl<T>(endpoint, query, variables);
+    if (data !== null) return data;
   }
 
   return null;


### PR DESCRIPTION
## Summary

Adds generic configurable subgraph fallback support so ArcNS can safely use Goldsky as the primary indexed data source while keeping the legacy The Graph endpoint as a fallback.

Endpoint order is now:

1. `NEXT_PUBLIC_SUBGRAPH_URL`
2. `NEXT_PUBLIC_SUBGRAPH_FALLBACK_URL`
3. `NEXT_PUBLIC_GOLDSKY_SUBGRAPH_URL` if configured and not duplicated
4. Existing RPC fallback through downstream `null` behavior

## Why

Goldsky product subgraph for ArcNS is deployed, healthy, active, and 100% synced on Arc Testnet.

Goldsky endpoint:

`https://api.goldsky.com/api/public/project_cmpn4idciwist01th4uejh86p/subgraphs/arcns-product/v0.1.0/gn`

Legacy The Graph endpoint remains available as fallback:

`https://api.studio.thegraph.com/query/1748590/arcnslatest/v3`

This allows a safe production configuration:

- Goldsky as primary indexed data source
- Legacy subgraph as secondary fallback
- RPC fallback preserved

## Changes

- Adds `NEXT_PUBLIC_SUBGRAPH_FALLBACK_URL`
- Keeps `NEXT_PUBLIC_SUBGRAPH_URL` as primary
- Keeps `NEXT_PUBLIC_GOLDSKY_SUBGRAPH_URL` as optional backward-compatible fallback
- Deduplicates endpoint URLs
- Preserves timeout/error/null-return behavior
- Updates env example and environment guide

## Safety

- No contract changes
- No deployment script changes
- No package/lockfile changes
- No secrets/env files changed
- No RPC fallback removal
- No production deployment in this PR

## Validation

- `npm --prefix frontend run lint` passed with existing warnings only
- `npm --prefix frontend run build` passed
- `git diff --check` passed