### PR TITLE
docs: refresh current ArcNS status

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Names are registered with USDC, owned as NFTs, and resolved entirely on-chain. N
 | Component | Status |
 |-----------|--------|
 | All 8 v3 contracts | Deployed on Arc Testnet (2026-04-24) |
-| Subgraph (`arcnslatest`) | Published on The Graph Studio |
+| Indexed data layer | Goldsky primary (Arc Testnet), The Graph Studio fallback, RPC fallback preserved |
 | Frontend (Next.js) | Functional, v3-wired, local dev |
 | Contract test suite | ~180 passing tests, zero failures |
 | Live smoke tests | 10 flows verified on-chain |
@@ -55,8 +55,10 @@ Any address can set a primary name via the ReverseRegistrar. The protocol stores
 ### NFT Ownership
 Names are ERC-721 tokens on the BaseRegistrar contracts. Token ID is `uint256(keccak256(label))`. `tokenURI` returns fully on-chain JSON metadata with an inline SVG image — no external fetch required.
 
-### Subgraph
-The `arcnslatest` subgraph indexes registrations, renewals, transfers, address record changes, and reverse record changes. It powers the portfolio view and transaction history in the frontend.
+### Indexed Data Layer
+ArcNS production uses Goldsky as the primary indexed data source on Arc Testnet. The legacy The Graph Studio endpoint is retained as a fallback, and direct RPC fallback is preserved for resilience.
+
+The indexed data layer powers registrations/renewals history, transfers, resolver record changes, reverse record changes, and portfolio views in the frontend.
 
 ---
 
@@ -130,7 +132,9 @@ Payment flow:
 | ArcNSPriceOracle | `0xde9b95B560f5e803f5Cc045f27285F0226913548` |
 | USDC (Arc Testnet) | `0x3600000000000000000000000000000000000000` |
 
-**Subgraph:** `https://api.studio.thegraph.com/query/1748590/arcnslatest/v3`  
+**Primary indexed endpoint (Goldsky):** `https://api.goldsky.com/api/public/project_cmpn4idciwist01th4uejh86p/subgraphs/arcns-product/v0.1.0/gn`
+**Fallback indexed endpoint (The Graph Studio):** `https://api.studio.thegraph.com/query/1748590/arcnslatest/v3`
+**RPC fallback:** `https://rpc.testnet.arc.network`
 **Explorer:** `https://testnet.arcscan.app`  
 **Canonical addresses:** `deployments/arc_testnet-v3.json` → `frontend/src/lib/generated-contracts.ts`
 
@@ -207,7 +211,8 @@ cp .env.example .env
 Frontend environment:
 ```bash
 # frontend/.env.local
-NEXT_PUBLIC_SUBGRAPH_URL=https://api.studio.thegraph.com/query/1748590/arcnslatest/v3
+NEXT_PUBLIC_SUBGRAPH_URL=https://api.goldsky.com/api/public/project_cmpn4idciwist01th4uejh86p/subgraphs/arcns-product/v0.1.0/gn
+NEXT_PUBLIC_SUBGRAPH_FALLBACK_URL=https://api.studio.thegraph.com/query/1748590/arcnslatest/v3
 NEXT_PUBLIC_RPC_URL=https://rpc.testnet.arc.network
 NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=<your_project_id>
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,8 @@ ArcNS is a decentralized naming protocol for Arc. It maps human-readable `.arc` 
 - **Live app:** https://arcns-app.vercel.app
 - **GitHub:** https://github.com/khenzarr/arcns
 - **Explorer:** https://testnet.arcscan.app
-- **Subgraph:** https://api.studio.thegraph.com/query/1748590/arcnslatest/v3
+- **Primary indexed endpoint (Goldsky):** https://api.goldsky.com/api/public/project_cmpn4idciwist01th4uejh86p/subgraphs/arcns-product/v0.1.0/gn
+- **Fallback indexed endpoint (The Graph Studio):** https://api.studio.thegraph.com/query/1748590/arcnslatest/v3
 
 ---
 
@@ -38,11 +39,11 @@ ArcNS is a decentralized naming protocol for Arc. It maps human-readable `.arc` 
 
 | Document | Purpose |
 |----------|---------|
-| [final/DEPLOYED_ADDRESSES.md](final/DEPLOYED_ADDRESSES.md) | All contract addresses, subgraph URL, explorer links |
+| [final/DEPLOYED_ADDRESSES.md](final/DEPLOYED_ADDRESSES.md) | All contract addresses, indexed endpoint URLs, explorer links |
 | [final/RELEASE_SUMMARY.md](final/RELEASE_SUMMARY.md) | What is live, what is v1-scope-only, what is not yet mainnet-ready |
 | [final/FINAL_STATUS.md](final/FINAL_STATUS.md) | Authoritative live status — what works, what is tested, what is not mainnet-ready |
 | [final/ENVIRONMENT_GUIDE.md](final/ENVIRONMENT_GUIDE.md) | `.env` and `.env.local` variable reference |
-| [final/SUBGRAPH_GUIDE.md](final/SUBGRAPH_GUIDE.md) | Subgraph build, deploy, and frontend consumption |
+| [final/SUBGRAPH_GUIDE.md](final/SUBGRAPH_GUIDE.md) | Indexing guide: Goldsky primary, The Graph fallback, RPC fallback behavior |
 | [final/SMOKE_TEST_RESULTS.md](final/SMOKE_TEST_RESULTS.md) | Live manual test results on Arc Testnet |
 
 ---
@@ -107,6 +108,11 @@ ArcNS is a decentralized naming protocol for Arc. It maps human-readable `.arc` 
 | [integration/wallet-integration-package.md](integration/wallet-integration-package.md) | Implementation-grade wallet integration spec |
 | [integration/dapp-fallback-ux.md](integration/dapp-fallback-ux.md) | In-app fallback UX while native ecosystem support is pending |
 | [integration/integration-reality-audit.md](integration/integration-reality-audit.md) | Phase 8A — what is available on-chain vs what external tools consume |
+| [integration/GOLDSKY_ARCNS_INTEGRATION_PLAN.md](integration/GOLDSKY_ARCNS_INTEGRATION_PLAN.md) | Goldsky integration plan and production indexing migration scope |
+| [integration/GOLDSKY_PHASE1_BUILD_READINESS.md](integration/GOLDSKY_PHASE1_BUILD_READINESS.md) | Goldsky Phase 1 build readiness report |
+| [integration/GOLDSKY_PHASE2_PRODUCT_DEPLOY_REPORT.md](integration/GOLDSKY_PHASE2_PRODUCT_DEPLOY_REPORT.md) | Goldsky Phase 2 product deployment report |
+| [integration/GOLDSKY_PHASE3_SYNC_PARITY_REPORT.md](integration/GOLDSKY_PHASE3_SYNC_PARITY_REPORT.md) | Goldsky Phase 3 sync/parity validation report |
+| [integration/GOLDSKY_PHASE3_FINAL_SYNC_PARITY_REPORT.md](integration/GOLDSKY_PHASE3_FINAL_SYNC_PARITY_REPORT.md) | Goldsky final sync/parity report (healthy/active/synced) |
 
 ---
 
@@ -115,5 +121,5 @@ ArcNS is a decentralized naming protocol for Arc. It maps human-readable `.arc` 
 | Document | Purpose |
 |----------|---------|
 | [grants/CIRCLE_GRANT_README.md](grants/CIRCLE_GRANT_README.md) | Circle 2026 Cohort 2 grant application overview |
-| [grants/DEMO_VIDEO_SCRIPT.md](grants/DEMO_VIDEO_SCRIPT.md) | 3–5 minute demo video script |
+| [final/FOUNDER_DEMO_SCRIPT.md](final/FOUNDER_DEMO_SCRIPT.md) | 3–5 minute live demo script |
 | [grants/INVESTOR_DECK_OUTLINE.md](grants/INVESTOR_DECK_OUTLINE.md) | 8–10 slide deck outline |

--- a/docs/final/DEPLOYED_ADDRESSES.md
+++ b/docs/final/DEPLOYED_ADDRESSES.md
@@ -64,13 +64,15 @@
 
 ---
 
-## Subgraph
+## Indexed Data Layer
 
 | Field | Value |
 |-------|-------|
-| Subgraph name | `arcnslatest` |
-| Query URL | `https://api.studio.thegraph.com/query/1748590/arcnslatest/v3` |
-| Hosted on | The Graph Studio |
+| Primary indexed endpoint | Goldsky `arcns-product/v0.1.0` |
+| Primary query URL | `https://api.goldsky.com/api/public/project_cmpn4idciwist01th4uejh86p/subgraphs/arcns-product/v0.1.0/gn` |
+| Fallback indexed endpoint | The Graph Studio `arcnslatest/v3` |
+| Fallback query URL | `https://api.studio.thegraph.com/query/1748590/arcnslatest/v3` |
+| RPC fallback | `https://rpc.testnet.arc.network` |
 
 ---
 

--- a/docs/final/FINAL_STATUS.md
+++ b/docs/final/FINAL_STATUS.md
@@ -27,7 +27,7 @@ This is a testnet deployment. No real funds are at risk. ArcNS is not a financia
 | Primary name set (My Domains) | ✅ Working | `ReverseRegistrar.setName()` |
 | NFT ownership (ERC-721) | ✅ Working | `BaseRegistrar.ownerOf(tokenId)` |
 | On-chain SVG metadata | ✅ Working | `tokenURI` returns base64 JSON + inline SVG |
-| Subgraph (`arcnslatest`) | ✅ Working | Indexed on The Graph Studio |
+| Indexed data layer | ✅ Working | Goldsky primary on Arc Testnet, The Graph Studio fallback, RPC fallback preserved |
 | Portfolio view (My Domains) | ✅ Working | Subgraph-first, RPC fallback |
 | Transaction history | ✅ Working | Registrations and renewals |
 | Wrong-network guard | ✅ Working | Blocks writes on wrong chain |
@@ -79,7 +79,7 @@ The Resolve page empty-state (search bar and Identity Inspector card) has minor 
 - **Not mainnet.** This is Arc Testnet. No real USDC. No real funds.
 - **External audit pending.** No external audit has been completed. The protocol has undergone internal review and security hardening, but external audit is required before mainnet.
 - **Treasury is an EOA.** Registration fees go to an EOA treasury. Migration to a multisig-controlled contract is planned.
-- **No ecosystem integrations yet.** ArcScan, wallets, and third-party dApps have not yet integrated ArcNS. Integration packages are ready and documented.
+- **External native integrations pending.** ArcScan, wallets, and third-party dApps have not yet completed native ArcNS integration. ArcNS now uses Goldsky indexing infrastructure in production and is listed in ArcLens under Identity.
 
 ---
 

--- a/docs/final/RELEASE_SUMMARY.md
+++ b/docs/final/RELEASE_SUMMARY.md
@@ -33,12 +33,14 @@ All 8 v3 contracts are deployed and operational:
 
 - Production app live at https://arcns-app.vercel.app
 - Pages: Home/Search, My Domains (portfolio + history + primary name), Resolve
-- Subgraph-first data with RPC fallback
+- Indexed data reads use Goldsky as primary, The Graph Studio as fallback, with RPC fallback preserved
 - Public resolution API: `/api/v1/resolve/name/{name}`, `/api/v1/resolve/address/{address}`
 
-### Subgraph
+### Indexed Data Layer
 
-- `arcnslatest` published on The Graph Studio
+- Goldsky primary indexed endpoint: `arcns-product/v0.1.0`
+- Goldsky query URL: `https://api.goldsky.com/api/public/project_cmpn4idciwist01th4uejh86p/subgraphs/arcns-product/v0.1.0/gn`
+- Legacy The Graph Studio fallback: `https://api.studio.thegraph.com/query/1748590/arcnslatest/v3`
 - Indexes: registrations, renewals, transfers, address records, reverse records
 
 ---

--- a/docs/final/SUBGRAPH_GUIDE.md
+++ b/docs/final/SUBGRAPH_GUIDE.md
@@ -1,15 +1,19 @@
-# ArcNS — Subgraph Guide
+# ArcNS — Indexing Guide
 
-**Subgraph name:** `arcnslatest`  
-**Query URL:** `https://api.studio.thegraph.com/query/1748590/arcnslatest/v3`  
-**Hosted on:** The Graph Studio  
+**Primary indexed endpoint (Goldsky):** `https://api.goldsky.com/api/public/project_cmpn4idciwist01th4uejh86p/subgraphs/arcns-product/v0.1.0/gn`
+**Fallback indexed endpoint (The Graph Studio):** `https://api.studio.thegraph.com/query/1748590/arcnslatest/v3`
+**RPC fallback:** `https://rpc.testnet.arc.network`
+**Primary Goldsky subgraph:** `arcns-product/v0.1.0`
+**Legacy Graph subgraph:** `arcnslatest`
 **Source:** `indexer/` directory
 
 ---
 
 ## Overview
 
-The `arcnslatest` subgraph indexes ArcNS contract events on Arc Testnet and provides fast, queryable access to domain registrations, renewals, transfers, address records, and reverse records.
+ArcNS production indexing on Arc Testnet uses Goldsky as the primary indexed data source, with The Graph Studio retained as a legacy indexed fallback and direct RPC fallback preserved.
+
+Both indexed endpoints provide fast, queryable access to domain registrations, renewals, transfers, address records, and reverse records.
 
 The subgraph is a **speed layer** — it provides indexed data for display purposes. It is not a trust layer. For security-sensitive operations (availability checks, ownership verification, transaction routing), always verify with direct RPC calls.
 
@@ -29,7 +33,29 @@ The subgraph is a **speed layer** — it provides indexed data for display purpo
 
 ---
 
-## Build and Deploy
+## Production Endpoint Order
+
+1. **Goldsky primary**
+2. **The Graph Studio fallback**
+3. **RPC fallback**
+
+The frontend queries in this order for resilient read behavior.
+
+---
+
+## Goldsky References (Production)
+
+For Goldsky integration and parity details, see:
+
+- [../integration/GOLDSKY_ARCNS_INTEGRATION_PLAN.md](../integration/GOLDSKY_ARCNS_INTEGRATION_PLAN.md)
+- [../integration/GOLDSKY_PHASE1_BUILD_READINESS.md](../integration/GOLDSKY_PHASE1_BUILD_READINESS.md)
+- [../integration/GOLDSKY_PHASE2_PRODUCT_DEPLOY_REPORT.md](../integration/GOLDSKY_PHASE2_PRODUCT_DEPLOY_REPORT.md)
+- [../integration/GOLDSKY_PHASE3_SYNC_PARITY_REPORT.md](../integration/GOLDSKY_PHASE3_SYNC_PARITY_REPORT.md)
+- [../integration/GOLDSKY_PHASE3_FINAL_SYNC_PARITY_REPORT.md](../integration/GOLDSKY_PHASE3_FINAL_SYNC_PARITY_REPORT.md)
+
+---
+
+## The Graph Studio Deploy Flow (Legacy / Fallback)
 
 ### Prerequisites
 
@@ -68,7 +94,7 @@ graph codegen
 graph build
 ```
 
-### Step 4 — Authenticate with Graph Studio
+### Step 4 — Authenticate with Graph Studio (legacy/fallback)
 
 ```bash
 graph auth --studio <YOUR_DEPLOY_KEY>
@@ -76,7 +102,7 @@ graph auth --studio <YOUR_DEPLOY_KEY>
 
 The deploy key is available in The Graph Studio dashboard. Never store it in files or commit it.
 
-### Step 5 — Deploy
+### Step 5 — Deploy (legacy/fallback)
 
 ```bash
 graph deploy arcnslatest
@@ -84,7 +110,7 @@ graph deploy arcnslatest
 
 You will be prompted for a version label (e.g. `v3`, `v3.1`).
 
-### Step 6 — Verify sync
+### Step 6 — Verify sync (legacy/fallback)
 
 - Open The Graph Studio dashboard
 - Confirm `arcnslatest` is syncing
@@ -92,14 +118,16 @@ You will be prompted for a version label (e.g. `v3`, `v3.1`).
 
 ---
 
-## Updating the Frontend Subgraph URL
+## Updating Indexed Endpoints in Frontend Environment
 
-After deploying a new subgraph version:
+When endpoint versions change:
 
-1. Get the new query URL from The Graph Studio (format: `https://api.studio.thegraph.com/query/<ID>/arcnslatest/<version>`)
+1. Get the primary Goldsky URL and fallback Graph Studio URL
 2. Update `frontend/.env.local`:
    ```
-   NEXT_PUBLIC_SUBGRAPH_URL=https://api.studio.thegraph.com/query/1748590/arcnslatest/<new-version>
+   NEXT_PUBLIC_SUBGRAPH_URL=https://api.goldsky.com/api/public/project_cmpn4idciwist01th4uejh86p/subgraphs/arcns-product/<version>/gn
+   NEXT_PUBLIC_SUBGRAPH_FALLBACK_URL=https://api.studio.thegraph.com/query/1748590/arcnslatest/<new-version>
+   NEXT_PUBLIC_RPC_URL=https://rpc.testnet.arc.network
    ```
 3. Update the Vercel environment variable in the Vercel project settings
 4. Redeploy the frontend

--- a/docs/grants/CIRCLE_GRANT_README.md
+++ b/docs/grants/CIRCLE_GRANT_README.md
@@ -54,7 +54,7 @@ Circle's USDC is the payment token for the entire ArcNS economy. This is not a r
 | Security migration | Complete (2026-04-29) |
 | Multisig (2-of-3 Safe) | Live |
 | Timelock (48h upgrade delay) | Live |
-| Subgraph (`arcnslatest`) | Published on The Graph Studio |
+| Indexed data layer | Goldsky primary (`arcns-product/v0.1.0`), The Graph Studio fallback, RPC fallback preserved |
 | Production frontend | Live at https://arcns-app.vercel.app |
 | Contract test suite | ~180 passing tests, zero failures |
 | External security audit | Not yet completed — required before mainnet |
@@ -78,7 +78,7 @@ Circle's USDC is the payment token for the entire ArcNS economy. This is not a r
 - `contracts/v3/` — all 8 v3 contracts
 - `deployments/arc_testnet-v3.json` — canonical deployed addresses
 - `frontend/` — Next.js 14 production frontend
-- `indexer/` — The Graph subgraph
+- `indexer/` — indexed data mappings and manifests (Goldsky primary, The Graph Studio fallback)
 - `docs/` — full documentation
 
 ---
@@ -143,9 +143,20 @@ Full address table: [docs/final/DEPLOYED_ADDRESSES.md](../final/DEPLOYED_ADDRESS
 
 ---
 
+## Post-submission reviewer update
+
+- Proposal was submitted and is currently in review.
+- The final demo video update was posted via Questbook comments (proposal body was not editable after submission).
+- Goldsky primary indexing is now live in production on Arc Testnet.
+- ArcNS remains live at https://arcns-app.vercel.app on Arc Testnet (pre-mainnet, external audit pending).
+- ArcNS is listed on ArcLens under the Identity category.
+- During the grant period, ArcNS reached 100+ holders and 142+ registered `.arc` / `.circle` names.
+
+---
+
 ## Demo Flow
 
-See [DEMO_VIDEO_SCRIPT.md](DEMO_VIDEO_SCRIPT.md) for the full 3–5 minute demo script.
+See [../final/FOUNDER_DEMO_SCRIPT.md](../final/FOUNDER_DEMO_SCRIPT.md) for the full 3–5 minute demo script.
 
 **Quick summary:**
 1. Home page — search for a name
@@ -164,7 +175,7 @@ See [DEMO_VIDEO_SCRIPT.md](DEMO_VIDEO_SCRIPT.md) for the full 3–5 minute demo 
 |-----|-------|
 | External audit pending | Required before mainnet. Audit prep package is ready. |
 | Treasury is an EOA | Migration to multisig contract is planned. |
-| No ecosystem integrations yet | Integration packages are ready. Adoption requires third-party work. |
+| External native integrations pending | Integration packages are ready. Adoption requires third-party implementation work. Goldsky indexing is live and ArcNS is listed on ArcLens (Identity). |
 | Not mainnet | Arc Testnet only. No real funds. |
 | Resolve empty-state polish | Minor UX polish deferred. Not a blocker. |
 
@@ -179,8 +190,9 @@ Full gap analysis: [docs/final/MAINNET_GAP_REPORT.md](../final/MAINNET_GAP_REPOR
 | Live app | https://arcns-app.vercel.app |
 | GitHub | https://github.com/khenzarr/arcns |
 | Explorer | https://testnet.arcscan.app |
-| Subgraph | https://api.studio.thegraph.com/query/1748590/arcnslatest/v3 |
-| Demo script | [DEMO_VIDEO_SCRIPT.md](DEMO_VIDEO_SCRIPT.md) |
+| Primary indexed endpoint (Goldsky) | https://api.goldsky.com/api/public/project_cmpn4idciwist01th4uejh86p/subgraphs/arcns-product/v0.1.0/gn |
+| Fallback indexed endpoint (The Graph Studio) | https://api.studio.thegraph.com/query/1748590/arcnslatest/v3 |
+| Demo script | [../final/FOUNDER_DEMO_SCRIPT.md](../final/FOUNDER_DEMO_SCRIPT.md) |
 | Deck outline | [INVESTOR_DECK_OUTLINE.md](INVESTOR_DECK_OUTLINE.md) |
 | Deployed addresses | [docs/final/DEPLOYED_ADDRESSES.md](../final/DEPLOYED_ADDRESSES.md) |
 | Audit scope | [docs/final/AUDIT_SCOPE.md](../final/AUDIT_SCOPE.md) |


### PR DESCRIPTION
## Summary

Refreshes public ArcNS documentation to reflect the current production and grant-review status.

## Updates

- Documents Goldsky as the primary indexed data source on Arc Testnet
- Documents legacy The Graph Studio as fallback
- Clarifies that RPC fallback remains preserved
- Updates deployed-address and indexing documentation
- Refreshes final status and release summary language
- Adds a post-submission reviewer update to the Circle grant README
- Keeps grant/Circle integration claims honest and avoids overclaiming planned integrations

## Current production indexing order

1. Goldsky product subgraph: `arcns-product/v0.1.0`
2. Legacy The Graph Studio fallback: `arcnslatest/v3`
3. Arc Testnet RPC fallback

## Safety

- Docs-only update
- No frontend source changes
- No contract changes
- No package/lockfile changes
- No env/secrets changes
- No deployment changes

## Validation

- `git diff --check` passed