### PR TITLE
docs: update official ArcNS domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ Names are registered with USDC, owned as NFTs, and resolved entirely on-chain. N
 
 The protocol is fully functional on testnet. Mainnet deployment is gated on an external security audit and operational hardening. See [Mainnet Gap Report](docs/final/MAINNET_GAP_REPORT.md) for the full checklist.
 
-**Production app:** https://arcns-app.vercel.app  
+**Production app:** https://arcname.services
+**Previous Vercel URL (legacy):** https://arcns-app.vercel.app
 **Grant reviewer entry point:** [docs/grants/CIRCLE_GRANT_README.md](docs/grants/CIRCLE_GRANT_README.md)
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,8 @@
 **Network:** Arc Testnet (Chain ID: 5042002)  
 **Version:** v3  
 **Status:** Live on testnet · Pre-mainnet  
-**Production App:** https://arcns-app.vercel.app
+**Production App:** https://arcname.services
+**Previous Vercel URL (legacy):** https://arcns-app.vercel.app
 
 ---
 
@@ -27,7 +28,8 @@
 
 ArcNS is a decentralized naming protocol for Arc. It maps human-readable `.arc` and `.circle` names to on-chain addresses, issues names as ERC-721 NFTs, and lets any address set a verified primary name. Registration and renewal fees are paid in USDC.
 
-- **Live app:** https://arcns-app.vercel.app
+- **Live app:** https://arcname.services
+- **Previous Vercel URL (legacy):** https://arcns-app.vercel.app
 - **GitHub:** https://github.com/khenzarr/arcns
 - **Explorer:** https://testnet.arcscan.app
 - **Primary indexed endpoint (Goldsky):** https://api.goldsky.com/api/public/project_cmpn4idciwist01th4uejh86p/subgraphs/arcns-product/v0.1.0/gn

--- a/docs/final/DEPLOYED_ADDRESSES.md
+++ b/docs/final/DEPLOYED_ADDRESSES.md
@@ -80,7 +80,8 @@
 
 | Field | Value |
 |-------|-------|
-| URL | https://arcns-app.vercel.app |
+| URL | https://arcname.services |
+| Previous Vercel URL (legacy) | https://arcns-app.vercel.app |
 | Hosting | Vercel |
 | Status | Live |
 

--- a/docs/final/FINAL_STATUS.md
+++ b/docs/final/FINAL_STATUS.md
@@ -3,13 +3,14 @@
 **Date:** 2026-05-09  
 **Network:** Arc Testnet (Chain ID: 5042002)  
 **Version:** v3  
-**Production App:** https://arcns-app.vercel.app
+**Production App:** https://arcname.services
+**Previous Vercel URL (legacy):** https://arcns-app.vercel.app
 
 ---
 
 ## Current Status: Live on Arc Testnet · Demo-Ready · Pre-Mainnet
 
-ArcNS is fully deployed and operational on Arc Testnet. The production frontend is live at https://arcns-app.vercel.app. Core registration, renewal, resolution, and primary-name flows are working end-to-end.
+ArcNS is fully deployed and operational on Arc Testnet. The production frontend is live at https://arcname.services. Core registration, renewal, resolution, and primary-name flows are working end-to-end.
 
 This is a testnet deployment. No real funds are at risk. ArcNS is not a financial product. Mainnet deployment is gated on an external security audit and operational hardening.
 

--- a/docs/final/RELEASE_SUMMARY.md
+++ b/docs/final/RELEASE_SUMMARY.md
@@ -4,7 +4,8 @@
 **Network:** Arc Testnet (Chain ID: 5042002)  
 **Initial Deployment:** 2026-04-24  
 **Security Migration:** 2026-04-29  
-**Production App:** https://arcns-app.vercel.app
+**Production App:** https://arcname.services
+**Previous Vercel URL (legacy):** https://arcns-app.vercel.app
 
 ---
 
@@ -31,10 +32,12 @@ All 8 v3 contracts are deployed and operational:
 
 ### Frontend
 
-- Production app live at https://arcns-app.vercel.app
+- Production app live at https://arcname.services
 - Pages: Home/Search, My Domains (portfolio + history + primary name), Resolve
 - Indexed data reads use Goldsky as primary, The Graph Studio as fallback, with RPC fallback preserved
 - Public resolution API: `/api/v1/resolve/name/{name}`, `/api/v1/resolve/address/{address}`
+
+> Historical note: earlier release/deployment material referenced `https://arcns-app.vercel.app`. The current official production domain is `https://arcname.services`.
 
 ### Indexed Data Layer
 

--- a/docs/grants/CIRCLE_GRANT_README.md
+++ b/docs/grants/CIRCLE_GRANT_README.md
@@ -55,7 +55,7 @@ Circle's USDC is the payment token for the entire ArcNS economy. This is not a r
 | Multisig (2-of-3 Safe) | Live |
 | Timelock (48h upgrade delay) | Live |
 | Indexed data layer | Goldsky primary (`arcns-product/v0.1.0`), The Graph Studio fallback, RPC fallback preserved |
-| Production frontend | Live at https://arcns-app.vercel.app |
+| Production frontend | Live at https://arcname.services |
 | Contract test suite | ~180 passing tests, zero failures |
 | External security audit | Not yet completed — required before mainnet |
 
@@ -63,7 +63,9 @@ Circle's USDC is the payment token for the entire ArcNS economy. This is not a r
 
 ## Live App
 
-**https://arcns-app.vercel.app**
+**https://arcname.services**
+
+Previous Vercel URL (legacy/reference): https://arcns-app.vercel.app
 
 - Home/Search: search and register `.arc` and `.circle` names
 - My Domains: portfolio, transaction history, primary name management
@@ -148,7 +150,9 @@ Full address table: [docs/final/DEPLOYED_ADDRESSES.md](../final/DEPLOYED_ADDRESS
 - Proposal was submitted and is currently in review.
 - The final demo video update was posted via Questbook comments (proposal body was not editable after submission).
 - Goldsky primary indexing is now live in production on Arc Testnet.
-- ArcNS remains live at https://arcns-app.vercel.app on Arc Testnet (pre-mainnet, external audit pending).
+- ArcNS official production domain is now https://arcname.services.
+- Prior submitted/grant material may still reference https://arcns-app.vercel.app.
+- ArcNS remains live on Arc Testnet (pre-mainnet, external audit pending).
 - ArcNS is listed on ArcLens under the Identity category.
 - During the grant period, ArcNS reached 100+ holders and 142+ registered `.arc` / `.circle` names.
 
@@ -187,7 +191,8 @@ Full gap analysis: [docs/final/MAINNET_GAP_REPORT.md](../final/MAINNET_GAP_REPOR
 
 | Resource | URL |
 |----------|-----|
-| Live app | https://arcns-app.vercel.app |
+| Live app | https://arcname.services |
+| Previous Vercel URL (legacy) | https://arcns-app.vercel.app |
 | GitHub | https://github.com/khenzarr/arcns |
 | Explorer | https://testnet.arcscan.app |
 | Primary indexed endpoint (Goldsky) | https://api.goldsky.com/api/public/project_cmpn4idciwist01th4uejh86p/subgraphs/arcns-product/v0.1.0/gn |

--- a/docs/integration/ECOSYSTEM_INTEGRATION_STATUS.md
+++ b/docs/integration/ECOSYSTEM_INTEGRATION_STATUS.md
@@ -50,9 +50,9 @@ Role: speed layer for display data. Not a trust layer for reverse resolution.
 
 | Surface | Status | Notes |
 |---------|--------|-------|
-| `GET /api/v1/resolve/name/{name}` | ✅ Live — `https://arcns-app.vercel.app` | Versioned, CORS, subgraph-first, RPC fallback, 30s cache. |
-| `GET /api/v1/resolve/address/{address}` | ✅ Live — `https://arcns-app.vercel.app` | Forward-confirmation enforced. `verified` field on all responses. |
-| `GET /api/v1/health` | ✅ Live — `https://arcns-app.vercel.app` | Returns chain context. |
+| `GET /api/v1/resolve/name/{name}` | ✅ Live — `https://arcname.services` | Versioned, CORS, subgraph-first, RPC fallback, 30s cache. |
+| `GET /api/v1/resolve/address/{address}` | ✅ Live — `https://arcname.services` | Forward-confirmation enforced. `verified` field on all responses. |
+| `GET /api/v1/health` | ✅ Live — `https://arcname.services` | Returns chain context. |
 | `GET /api/resolve/name/[name]` (unversioned) | ✅ Exists (legacy) | Subgraph-first, RPC fallback. No CORS, no versioning. Prefer v1 routes. |
 | `GET /api/resolve/address/[address]` (unversioned) | ✅ Exists (legacy) | Missing forward-confirmation. Prefer v1 routes. |
 
@@ -173,7 +173,7 @@ A canonical public ArcNS resolution API removes the need for every third-party i
 
 ### Current adapter status
 
-The v1 adapter is live at `https://arcns-app.vercel.app`. The `/api/v1/resolve/name/{name}`, `/api/v1/resolve/address/{address}`, and `/api/v1/health` endpoints are publicly accessible. Forward-confirmation, name normalization, TLD validation, CORS, versioning, and stable error schema are all implemented and deployed. Rate limiting and request logging are not yet implemented.
+The v1 adapter is live at `https://arcname.services`. The `/api/v1/resolve/name/{name}`, `/api/v1/resolve/address/{address}`, and `/api/v1/health` endpoints are publicly accessible. Forward-confirmation, name normalization, TLD validation, CORS, versioning, and stable error schema are all implemented and deployed. Rate limiting and request logging are not yet implemented.
 
 ---
 
@@ -233,7 +233,9 @@ The following is the practical execution order after Phase 8, prioritized by imp
 
 1. ✅ **Fixed the address resolution API route** — forward-confirmation added, `verified: boolean` returned.
 2. ✅ **Added name normalization and TLD validation** to the name resolution route.
-3. ✅ **Deployed the adapter as a public hosted service** — live at `https://arcns-app.vercel.app`. Versioning, CORS, health endpoint all in place.
+3. ✅ **Deployed the adapter as a public hosted service** — live at `https://arcname.services`. Versioning, CORS, health endpoint all in place.
+
+> Legacy reference: prior deployment notes used `https://arcns-app.vercel.app`.
 4. **Add the unified address-or-name input to the Resolve page** — low effort, high user value, no third-party dependency.
 5. **Add prominent copy-address CTA and "use in wallet" helper** — makes the fallback UX discoverable and sets correct expectations.
 6. **Add rate limiting** — required before high-traffic public exposure.

--- a/docs/integration/TIER1_ADAPTER_STATUS.md
+++ b/docs/integration/TIER1_ADAPTER_STATUS.md
@@ -3,7 +3,8 @@
 **Date:** 2026-04-26  
 **Network:** Arc Testnet (Chain ID: 5042002)  
 **Milestone:** Tier 1 — Public Resolution Adapter / API Hardening  
-**Status:** Complete · Live at `https://arcns-app.vercel.app`
+**Status:** Complete · Live at `https://arcname.services`
+**Previous Vercel URL (legacy):** `https://arcns-app.vercel.app`
 
 ---
 
@@ -107,9 +108,9 @@ The adapter is deployed and publicly accessible. Verified live endpoints:
 
 | Endpoint | Status |
 |----------|--------|
-| `https://arcns-app.vercel.app/api/v1/health` | ✅ Live |
-| `https://arcns-app.vercel.app/api/v1/resolve/name/{name}` | ✅ Live |
-| `https://arcns-app.vercel.app/api/v1/resolve/address/{address}` | ✅ Live |
+| `https://arcname.services/api/v1/health` | ✅ Live |
+| `https://arcname.services/api/v1/resolve/name/{name}` | ✅ Live |
+| `https://arcname.services/api/v1/resolve/address/{address}` | ✅ Live |
 
 **Deployment note:** The Vercel build requires ABI artifact JSON files at `frontend/src/lib/abis/`. The v3 ABI artifacts were copied from the repo-root `artifacts/` path into that directory, and `frontend/src/lib/abis.ts` imports were updated accordingly. The hosted build cannot resolve paths outside the `frontend/` tree.
 
@@ -132,7 +133,7 @@ The adapter is deployed and publicly accessible. Verified live endpoints:
 
 ### Adapter is live and consumable
 
-The public base URL `https://arcns-app.vercel.app` is stable. ArcScan, wallet teams, and third-party dApps can integrate against it immediately. No further adapter changes are required for initial ecosystem handoff.
+The public base URL `https://arcname.services` is stable. ArcScan, wallet teams, and third-party dApps can integrate against it immediately. No further adapter changes are required for initial ecosystem handoff.
 
 ### Docs ready for third-party handoff
 
@@ -184,4 +185,4 @@ Recommended path:
 | 1F — Status | This document | ✅ |
 | **2E — URL update** | **Public URL documented, stale local-only wording removed** | ✅ |
 
-**Tier 1 is complete. The ArcNS public resolution adapter is live at `https://arcns-app.vercel.app`.**
+**Tier 1 is complete. The ArcNS public resolution adapter is live at `https://arcname.services`.**

--- a/docs/integration/TIER2_PUBLIC_ADAPTER_STATUS.md
+++ b/docs/integration/TIER2_PUBLIC_ADAPTER_STATUS.md
@@ -3,19 +3,20 @@
 **Date:** 2026-04-26  
 **Network:** Arc Testnet (Chain ID: 5042002)  
 **Milestone:** Tier 2 — Public Adapter Deployment  
-**Status:** Complete · Live at `https://arcns-app.vercel.app`
+**Status:** Complete · Live at `https://arcname.services`
 
 ---
 
 ## 1. What Is Now Publicly Reachable
 
-**Public base URL:** `https://arcns-app.vercel.app`
+**Public base URL:** `https://arcname.services`
+**Previous Vercel URL (legacy):** `https://arcns-app.vercel.app`
 
 | Endpoint | Status |
 |----------|--------|
-| `GET https://arcns-app.vercel.app/api/v1/health` | ✅ Live |
-| `GET https://arcns-app.vercel.app/api/v1/resolve/name/{name}` | ✅ Live |
-| `GET https://arcns-app.vercel.app/api/v1/resolve/address/{address}` | ✅ Live |
+| `GET https://arcname.services/api/v1/health` | ✅ Live |
+| `GET https://arcname.services/api/v1/resolve/name/{name}` | ✅ Live |
+| `GET https://arcname.services/api/v1/resolve/address/{address}` | ✅ Live |
 
 **Hosting surface:** The adapter is co-located with the ArcNS Next.js frontend on Vercel. The `/api/v1/*` routes are standard Next.js App Router API routes served from the same deployment. This is acceptable for the current testnet phase.
 
@@ -153,7 +154,7 @@ After ArcScan outreach is initiated, the next priority is wallet partner outreac
 | 2A — Hosting plan | `docs/integration/adapter-hosting-plan.md` | ✅ |
 | 2B — Deployment audit | `docs/integration/adapter-deployment-audit.md` | ✅ |
 | 2C — ABI artifact fix | `frontend/src/lib/abis/` populated, `abis.ts` imports updated | ✅ |
-| 2D — Vercel deployment | Adapter live at `https://arcns-app.vercel.app` | ✅ |
+| 2D — Vercel deployment | Adapter live at `https://arcname.services` | ✅ |
 | 2E — Docs / URL update | All integration docs updated with live URL, stale wording removed | ✅ |
 | 2F — Final status | This document | ✅ |
 

--- a/docs/integration/public-adapter-api.md
+++ b/docs/integration/public-adapter-api.md
@@ -3,7 +3,8 @@
 **Version:** v1  
 **Network:** Arc Testnet (Chain ID: 5042002)  
 **Status:** Live · Publicly hosted  
-**Public base URL:** `https://arcns-app.vercel.app`  
+**Public base URL:** `https://arcname.services`
+**Previous Vercel URL (legacy):** `https://arcns-app.vercel.app`
 **Base path:** `/api/v1`
 
 ---
@@ -14,9 +15,9 @@ The adapter is live and publicly accessible:
 
 | Endpoint | URL |
 |----------|-----|
-| Health | `https://arcns-app.vercel.app/api/v1/health` |
-| Name resolution | `https://arcns-app.vercel.app/api/v1/resolve/name/{name}` |
-| Address resolution | `https://arcns-app.vercel.app/api/v1/resolve/address/{address}` |
+| Health | `https://arcname.services/api/v1/health` |
+| Name resolution | `https://arcname.services/api/v1/resolve/name/{name}` |
+| Address resolution | `https://arcname.services/api/v1/resolve/address/{address}` |
 
 ---
 

--- a/docs/integration/public-adapter-deploy-readiness.md
+++ b/docs/integration/public-adapter-deploy-readiness.md
@@ -2,7 +2,8 @@
 
 **Date:** 2026-04-26  
 **Status:** Live · Publicly hosted on Vercel  
-**Public base URL:** `https://arcns-app.vercel.app`
+**Public base URL:** `https://arcname.services`
+**Previous Vercel URL (legacy):** `https://arcns-app.vercel.app`
 
 ---
 
@@ -10,13 +11,13 @@
 
 ### What is implemented and live
 
-The adapter is deployed and publicly accessible at `https://arcns-app.vercel.app`. The following endpoints are verified live:
+The adapter is deployed and publicly accessible at `https://arcname.services`. The following endpoints are verified live:
 
 | Endpoint | Status |
 |----------|--------|
-| `https://arcns-app.vercel.app/api/v1/health` | ✅ Live |
-| `https://arcns-app.vercel.app/api/v1/resolve/name/{name}` | ✅ Live |
-| `https://arcns-app.vercel.app/api/v1/resolve/address/{address}` | ✅ Live |
+| `https://arcname.services/api/v1/health` | ✅ Live |
+| `https://arcname.services/api/v1/resolve/name/{name}` | ✅ Live |
+| `https://arcname.services/api/v1/resolve/address/{address}` | ✅ Live |
 
 **Note on `not_found` responses:** A name that exists on-chain but has no `addr` record set (e.g. `test1.arc`) correctly returns `status: "not_found"` with hint `"Name has no address record set."` — this is expected and correct behavior, not a bug.
 
@@ -167,7 +168,7 @@ Malformed inputs are rejected at the validation layer with HTTP 400. No RPC or s
 - [x] CORS preflight (`OPTIONS`) handlers
 - [x] Health endpoint
 - [x] 65 passing adapter tests
-- [x] **Deployed to public host** — `https://arcns-app.vercel.app`
+- [x] **Deployed to public host** — `https://arcname.services`
 - [x] **Public endpoints verified live**
 
 ### Ready with small changes
@@ -190,6 +191,8 @@ Malformed inputs are rejected at the validation layer with HTTP 400. No RPC or s
 
 ## 6. Time to Public Deployment
 
-**Deployment is complete.** The adapter is live at `https://arcns-app.vercel.app`.
+**Deployment is complete.** The adapter is live at `https://arcname.services`.
+
+Historical note: earlier deployment material referenced `https://arcns-app.vercel.app`.
 
 The remaining work items (rate limiting, logging, monitoring) are operational improvements for production hardening, not blockers for ecosystem integration outreach.

--- a/docs/integration/wallet-integration-package.md
+++ b/docs/integration/wallet-integration-package.md
@@ -135,7 +135,7 @@ GET /api/v1/resolve/address/{address}
 
 The `/address/` endpoint will include a `verified` field — `true` only if forward-confirmation passed. Wallets must check `verified: true` before displaying a primary name.
 
-The ArcNS resolution API is publicly hosted at `https://arcns-app.vercel.app`. Wallets may use the v1 endpoints directly. For security-critical operations (sending funds), always verify the returned address via direct RPC before executing a transaction.
+The ArcNS resolution API is publicly hosted at `https://arcname.services`. Wallets may use the v1 endpoints directly. Previous Vercel URL (legacy): `https://arcns-app.vercel.app`. For security-critical operations (sending funds), always verify the returned address via direct RPC before executing a transaction.
 
 ### 3.4 Minimum ABI required
 


### PR DESCRIPTION
## Summary

Updates public ArcNS documentation to reflect the new official production domain:

`https://arcname.services`

The previous Vercel URL remains documented only as a legacy/fallback or historical reference where appropriate.

## Updates

- Sets `https://arcname.services` as the canonical public app URL
- Keeps `https://arcns-app.vercel.app` as legacy/fallback/reference only
- Updates root README, docs index, final docs, grant reviewer docs, and integration docs
- Preserves current production indexing language:
  - Goldsky primary indexed data source
  - legacy The Graph fallback
  - RPC fallback preserved
- Keeps grant status and testnet/pre-mainnet/audit-pending wording honest

## Safety

- Docs-only update
- No frontend source changes
- No contract changes
- No package/lockfile changes
- No env/secrets changes
- No deployment changes

## Validation

- `git diff --check` passed