### PR TITLE
chore: remediate ArcNS brand legal copy readiness

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -3,6 +3,25 @@ Copyright (c) 2026 ArcNS contributors
 
 -----------------------------------------------------------------------------
 
+Project Independence and Third-Party Marks
+
+ArcNS is an independent name service built on Arc Testnet. ArcNS is not
+affiliated with, endorsed by, or sponsored by Circle unless separately agreed
+in writing. Arc is a trademark of Circle Internet Group, Inc. and/or its
+affiliates.
+
+The ArcNS project claims no ownership of the Arc or Circle names, marks, logos,
+or other brand assets. References to Arc Testnet and Circle are descriptive and
+do not claim official status, endorsement, sponsorship, partnership, or approval.
+
+".circle" is an ArcNS testnet namespace and does not imply Circle endorsement,
+sponsorship, affiliation, or ownership.
+
+ArcNS is live on Arc Testnet for testing and demonstration. No mainnet or public
+launch, financial result, legal outcome, or continued service is promised.
+
+-----------------------------------------------------------------------------
+
 Branding and Reserved Names
 
 "ArcNS", "Arc Name Service", and associated logos and visual identifiers are

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # ArcNS — Arc Name Service
 
-ArcNS is a decentralized naming protocol built for Arc Testnet. It maps human-readable names ending in `.arc` and `.circle` to on-chain addresses, issues names as ERC-721 NFTs, and lets any address set a verified primary name for its on-chain identity.
+**Independent decentralized naming service built on Arc Testnet.**
+
+ArcNS maps human-readable names ending in `.arc` and `.circle` to on-chain addresses, issues names as ERC-721 NFTs for selected registration periods, and lets any address set a verified primary name.
+
+ArcNS is an independent name service built on Arc Testnet. ArcNS is not affiliated with, endorsed by, or sponsored by Circle unless separately agreed in writing. Arc is a trademark of Circle Internet Group, Inc. and/or its affiliates.
+
+> `.circle` is an ArcNS testnet namespace and does not imply Circle endorsement, sponsorship, affiliation, or ownership.
 
 Names are registered with USDC, owned as NFTs, and resolved entirely on-chain. No off-chain infrastructure is required to read or verify a name.
 
@@ -33,7 +39,7 @@ Names are registered with USDC, owned as NFTs, and resolved entirely on-chain. N
 
 The protocol is fully functional on testnet. Mainnet deployment is gated on an external security audit and operational hardening. See [Mainnet Gap Report](docs/final/MAINNET_GAP_REPORT.md) for the full checklist.
 
-**Production app:** https://arcname.services
+**Public testnet app:** https://arcname.services
 
 **Previous Vercel URL (legacy):** https://arcns-app.vercel.app
 
@@ -59,7 +65,7 @@ Any address can set a primary name via the ReverseRegistrar. The protocol stores
 Names are ERC-721 tokens on the BaseRegistrar contracts. Token ID is `uint256(keccak256(label))`. `tokenURI` returns fully on-chain JSON metadata with an inline SVG image — no external fetch required.
 
 ### Indexed Data Layer
-ArcNS production uses Goldsky as the primary indexed data source on Arc Testnet. The legacy The Graph Studio endpoint is retained as a fallback, and direct RPC fallback is preserved for resilience.
+The live testnet frontend uses Goldsky as the primary indexed data source on Arc Testnet. The legacy The Graph Studio endpoint is retained as a fallback, and direct RPC fallback is preserved for resilience.
 
 The indexed data layer powers registrations/renewals history, transfers, resolver record changes, reverse record changes, and portfolio views in the frontend.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 **Network:** Arc Testnet (Chain ID: 5042002)  
 **Version:** v3  
 **Status:** Live on testnet · Pre-mainnet  
-**Production App:** https://arcname.services
+**Public Testnet App:** https://arcname.services
 **Previous Vercel URL (legacy):** https://arcns-app.vercel.app
 
 ---
@@ -26,7 +26,9 @@
 
 ## Product Overview
 
-ArcNS is a decentralized naming protocol for Arc. It maps human-readable `.arc` and `.circle` names to on-chain addresses, issues names as ERC-721 NFTs, and lets any address set a verified primary name. Registration and renewal fees are paid in USDC.
+ArcNS is an independent naming protocol deployed on Arc Testnet. It maps human-readable `.arc` and `.circle` testnet names to on-chain addresses, issues names as ERC-721 NFTs with registration periods and renewal requirements, and lets any address set a verified primary name. Registration and renewal fees are paid in testnet USDC.
+
+ArcNS is not affiliated with, endorsed by, or sponsored by Circle unless separately agreed in writing. Arc is a trademark of Circle Internet Group, Inc. and/or its affiliates. `.circle` is an ArcNS testnet namespace and does not imply Circle endorsement, sponsorship, affiliation, or ownership.
 
 - **Live app:** https://arcname.services
 - **Previous Vercel URL (legacy):** https://arcns-app.vercel.app

--- a/docs/brand/ARCNS_ARC_BRAND_GUIDELINE_AUDIT_REPORT.md
+++ b/docs/brand/ARCNS_ARC_BRAND_GUIDELINE_AUDIT_REPORT.md
@@ -1,0 +1,177 @@
+# ArcNS — Arc Brand Guideline and Mainnet-Readiness Brand/Legal Copy Audit
+
+**Audit date:** 2026-08-01  
+**Canonical public site reviewed:** `https://arcname.services`  
+**Guideline source:** `https://www.arc.io/brand-guidelines-and-partner-toolkit`  
+**Repository scope:** frontend copy, metadata/configuration, README, NOTICE, `docs/final`, `docs/grants`, `docs/integration`, frontend public assets, links, and footer/legal surfaces.  
+**Status:** Pre-mainnet review; no files other than this report were changed by this audit.
+
+## Executive summary
+
+ArcNS / Arc Name Service is intentionally retained as the project and domain identity. The primary mitigation is not a rename: publish clear independent-project, trademark-attribution, namespace, lifecycle, and launch-status language wherever users or reviewers can reasonably infer Arc or Circle affiliation.
+
+The current repository accurately documents that ArcNS is on Arc Testnet and that an external audit is pending in several technical-status documents. However, public-facing and grant-facing language still creates material brand, affiliation, and mainnet-readiness risk:
+
+- the app lacks visible Terms, Privacy, trademark attribution, and an independent-project disclaimer;
+- `.circle` is presented as a Circle-aligned namespace without a non-endorsement disclaimer;
+- some materials call ArcNS “the identity layer” or “the naming system” for Arc, which can imply official or ecosystem-wide designation;
+- “production frontend/app” describes a testnet service, while legal, audit, and operational gates remain incomplete;
+- the registration UI says “Own forever,” although the product has registration periods, expiry, and renewal;
+- the deployed site metadata still describes `.arc` as “Official Domain”; and
+- the README labels the project “Decentralized naming on Arc Network,” while the reviewed deployment is explicitly Arc Testnet.
+
+**Brand/mainnet copy decision: NO-GO for a public mainnet brand/legal launch until all Must-fix items are resolved and Arc/Circle legal/brand review is completed.** This is a branding/legal-copy decision only; it does not replace the separate technical mainnet blockers.
+
+## Source guideline summary
+
+The Arc brand-guideline / partner-toolkit page was used as the governing source for this review. Apply its current published terms before publication and preserve any approval requirements for supplied marks or partner statements. The operational interpretation used here is:
+
+1. Do not state or imply that an unaffiliated product is official Arc/Circle infrastructure, a partner, endorsed, sponsored, or approved without a separate written agreement.
+2. Do not use, alter, combine, imitate, or make an Arc mark more prominent than the independent product mark unless the guideline and a written permission path expressly allow it.
+3. Use only approved Arc brand assets and required trademark notices when permission to use them exists.
+4. Use accurate network and launch descriptions; “mainnet,” “production,” “secure,” “audited,” and similar claims require substantiation and must not outrun the documented status.
+5. Distinguish an independently operated namespace from a Circle-owned, Circle-approved, or official namespace.
+
+This report is an implementation and copy-risk assessment, not legal advice and not a substitute for Circle/Arc written approval or counsel review.
+
+## Site findings
+
+| Priority | Finding | Evidence | Risk / required disposition |
+|---|---|---|---|
+| Must fix before mainnet | The registration copy says “Own forever” while the product has expiry and renewal. | `frontend/src/app/register/page.tsx:936`, `frontend/src/app/register/page.tsx:1050`; renewal/expiry are documented in `docs/final/FINAL_STATUS.md:25` and `README.md:122`. | Replace with time-bounded NFT registration language. “Forever” is materially misleading if names expire without renewal. |
+| Must fix before mainnet | `.circle` is a selectable public namespace with no visible Circle non-endorsement disclaimer. | `frontend/src/app/page.tsx:38-39`; `frontend/src/app/register/page.tsx:72-73`; `frontend/src/components/Footer.tsx:1-47`. | Add the namespace disclaimer adjacent to registration/TLD selection and in Terms. Do not describe it as Circle-aligned unless permission is documented. |
+| Must fix before mainnet | No visible Terms, Privacy, trademark/brand notice, or independent-project disclaimer appears in the footer. | `frontend/src/components/Footer.tsx:1-47`. | Add working legal pages and footer links before public mainnet launch; no “coming soon” placeholders. |
+| Must fix before mainnet | WalletConnect metadata still identifies `https://arcns.app`, not the stated canonical site. | `frontend/src/lib/wagmiConfig.ts:22-25`. | Correct the canonical URL and icon host. This also avoids an apparent “official domain” mismatch. |
+| Should fix before public grant/mainnet review | App metadata says “Secure .arc and .circle naming …”. | `frontend/src/app/layout.tsx:20-27`. | “Secure” is an unqualified security claim while the external audit is pending. Use precise, qualified language or remove it. |
+| Should fix before public grant/mainnet review | Page metadata calls the site “The official naming service for Arc Network.” | deployed `https://arcname.services` metadata / site review. | Remove “official” unless a written Arc/Circle authorization supports it. Use “an independent name service built on Arc Testnet.” |
+| Should fix before public grant/mainnet review | Main page says “The official naming layer for Arc,” “The identity layer for Arc,” and “Native identity.” | `frontend/src/app/page.tsx:42`, `frontend/src/app/page.tsx:113`, `frontend/src/app/page.tsx:335`. | These claims can imply platform appointment or affiliation. Use “an independent naming service for Arc Testnet” and avoid “native” unless contractually authorized. |
+| Should fix before public grant/mainnet review | Public-facing app footer labels the service “Built on Arc Testnet,” but lacks the accompanying independence/attribution notice. | `frontend/src/components/Footer.tsx:21-24`. | “Built on” is acceptable as a factual technical statement when paired with the required disclaimer and accurate testnet status. |
+| Acceptable / no issue | The app’s `.arc` and `.circle` feature labels are concise and understandable. | `frontend/src/app/page.tsx:38-39`. | Retain, but add a short namespace disclosure nearby. |
+
+## GitHub / README findings
+
+| Priority | Finding | Evidence | Recommended disposition |
+|---|---|---|---|
+| Should fix before public grant/mainnet review | README title/subtitle says “Decentralized naming on Arc Network,” not Arc Testnet. | `README.md:1-5`. | State Arc Testnet consistently until mainnet is live. |
+| Should fix before public grant/mainnet review | README says `.arc` and `.circle` names can be “registered, renewed, and resolved,” but no Circle namespace disclaimer appears in the overview. | `README.md:5-8`. | Add independent-project and `.circle` non-endorsement language in the first overview section. |
+| Nice to have | README includes accurate expiry/renewal material and a direct pre-mainnet status section. | `README.md:122-135`, `README.md:465-494`. | Keep this material; surface a brief version closer to registration claims. |
+| Must fix before mainnet | `NOTICE` is empty. | `NOTICE:1`. | Add third-party trademark attribution and project ownership/legal notice; coordinate exact wording with counsel/Arc/Circle. |
+| Should fix before public grant/mainnet review | Documentation uses “Production frontend deployed” and “Production App” for a testnet service. | `docs/final/MAINNET_GAP_REPORT.md:123`; `docs/final/FINAL_STATUS.md:6,13`. | Use “public testnet frontend” / “live testnet app.” |
+| Should fix before public grant/mainnet review | Grant deck repeatedly positions ArcNS as “The Identity Layer for Arc,” says `.arc` is “native to Arc,” and calls `.circle` “dedicated … for Circle-aligned identities.” | `docs/grants/INVESTOR_DECK_OUTLINE.md:9,51-58,156-162`. | Replace with non-exclusive, independent language and remove the Circle-aligned implication absent written permission. |
+| Nice to have | Grant deck accurately says pre-mainnet and external audit not completed. | `docs/grants/INVESTOR_DECK_OUTLINE.md:99-112,120-133`. | Retain, and add legal/brand review as an explicit launch gate. |
+
+## Asset / logo findings
+
+1. Repository asset review found ArcNS-owned visual assets including `frontend/public/arcns/arcns-logo.svg`, `frontend/public/arcns/arcns-emblem.svg`, and `frontend/src/app/icon.svg`.
+2. The reviewed paths did **not** reveal a separately named Arc or Circle logo file. No finding establishes that an official Arc logo is used, altered, or made more prominent than the ArcNS mark.
+3. The ArcNS asset names and the rendered site should nevertheless be reviewed by an authorized Arc/Circle brand reviewer for visual similarity, combination-mark risk, color/shape collision, and relative prominence. This code audit cannot grant trademark clearance.
+4. Before public mainnet, maintain an asset inventory with source, license/permission, modification status, and approved-use scope. Do not combine ArcNS and Arc marks into a single lockup without express written approval.
+
+**Required check result:** no Arc logo use was identified by filename/content inspection in the scoped frontend public assets; no conclusion of clearance is implied. The ArcNS logo should be treated as unapproved for Arc/Circle co-branding until independently reviewed.
+
+## Legal / footer findings
+
+| Requirement | Result | Priority |
+|---|---|---|
+| Independent-project disclaimer | Missing from footer and primary public surfaces. | Must fix before mainnet |
+| Arc/Circle trademark attribution | Missing from `NOTICE`, footer, and primary legal surface. | Must fix before mainnet |
+| Terms of Service | No working footer link identified. | Must fix before mainnet |
+| Privacy Policy | No working footer link identified. | Must fix before mainnet |
+| Trademark / Brand Notice | Missing. | Must fix before mainnet |
+| `.circle` non-endorsement disclosure | Missing. | Must fix before mainnet |
+| “Official Domain” confusion | Site metadata/public copy uses “Official Domain” terminology. | Should fix before public grant/mainnet review |
+
+Do not publish placeholders such as “coming soon” as a substitute for these required notices on a public mainnet service.
+
+## Mainnet-readiness copy findings
+
+The repository’s technical status documents correctly identify external audit, real mainnet USDC configuration, treasury migration, timelock hardening, infrastructure, monitoring, and legal/branding review as incomplete:
+
+- `docs/final/MAINNET_GAP_REPORT.md:15-26,30-43,105-108,131-135`
+- `docs/final/FINAL_STATUS.md:11-15,43-57,78-83`
+
+The following public-copy corrections are required:
+
+1. Do not call the pre-mainnet service a “production app” or “production frontend.” Say “public testnet app,” “testnet deployment,” or “demo-ready on Arc Testnet.”
+2. Do not say “secure” without scope and evidence. Audit-pending status means no blanket security assurance. If retained, qualify it with architecture-specific facts and link to the status/gap report.
+3. Do not say a name is owned “forever.” Names are ERC-721 NFTs **for the selected registration period** and require renewal before expiry to remain registered.
+4. Do not announce or imply mainnet readiness. Mainnet deployment remains gated on external audit, mainnet USDC configuration, operational hardening, and final legal/brand review.
+5. Do not characterize an unaffiliated third party as a Circle partner, Arc partner, official service, or endorsed product without a separate written agreement.
+
+## Risk matrix
+
+| ID | Risk | Severity | Likelihood | Required action | Launch effect |
+|---|---|---:|---:|---|---|
+| B-01 | Implied Arc/Circle official status | High | High | Remove “official,” “identity layer,” “naming system,” and unapproved “native” claims; add independence notice. | Block public mainnet brand launch |
+| B-02 | `.circle` implies Circle endorsement | High | High | Add disclosure at selector, registration, Terms, README, and grants; remove “Circle-aligned” copy. | Block public mainnet brand launch |
+| L-01 | Missing Terms, Privacy, trademark notice, and attribution | High | High | Publish complete legal pages and footer links. | Block public mainnet brand launch |
+| C-01 | “Own forever” conflicts with expiry/renewal | High | High | Replace every instance with registration-period/renewal language. | Block public mainnet brand launch |
+| C-02 | Unqualified “secure” while audit pending | Medium | High | Remove or qualify and link to audit/status disclosure. | Block public grant/mainnet review |
+| S-01 | “Production” label on testnet service | Medium | High | Replace with “public testnet app/deployment.” | Block public grant/mainnet review |
+| A-01 | Mark/logo permission and similarity not documented | High | Medium | Obtain brand/legal visual review and retain approval record. | Block use of any official Arc/Circle asset; mainnet hold if such assets are used |
+| U-01 | Canonical-site inconsistency (`arcns.app` vs `arcname.services`) | Medium | Medium | Standardize URL in metadata, WalletConnect, docs, and assets. | Block public review until corrected |
+
+## Exact files / strings to change
+
+| Priority | File | Current string / surface | Replacement direction |
+|---|---|---|---|
+| Must | `frontend/src/app/register/page.tsx` | `Own forever` (including `:936`, `:1050`) | “Receive an ERC-721 name NFT for your selected registration period. Renew before expiry to keep it registered.” |
+| Must | `frontend/src/components/Footer.tsx` | Footer has no legal/disclaimer links | Add active Terms, Privacy, Trademark/Brand Notice, and independent-project disclosure. |
+| Must | `NOTICE` | Empty file | Add approved Arc/Circle attribution and independent-project notice. |
+| Must | `frontend/src/app/page.tsx` and `frontend/src/app/register/page.tsx` | `.circle` selector/marketing with no disclosure | Add concise `.circle` testnet namespace / no-endorsement notice adjacent to selection. |
+| Should | `frontend/src/app/layout.tsx` | `Secure .arc and .circle naming …` | “Human-readable `.arc` and `.circle` names on Arc Testnet” plus status link; omit “secure.” |
+| Should | site metadata at `https://arcname.services` | `Official Domain` / official naming-service language | Remove “official”; use independent-project attribution. |
+| Should | `frontend/src/app/page.tsx` | `The official naming layer for Arc`; `The identity layer for Arc`; `Native identity` | Use “An independent name service built on Arc Testnet”; “Human-readable names for Arc Testnet addresses.” |
+| Should | `frontend/src/lib/wagmiConfig.ts` | `url: "https://arcns.app"`; `icons: ["https://arcns.app/favicon.ico"]` | Replace with the confirmed canonical `https://arcname.services` URLs. |
+| Should | `README.md` | `Decentralized naming on Arc Network` | “Independent decentralized naming service built on Arc Testnet.” |
+| Should | `docs/final/FINAL_STATUS.md` | `Production App`, `production frontend` | “Public testnet app” / “live testnet frontend.” |
+| Should | `docs/final/MAINNET_GAP_REPORT.md` | `Production frontend deployed` | “Public testnet frontend deployed.” |
+| Should | `docs/grants/INVESTOR_DECK_OUTLINE.md` | `The Identity Layer for Arc`; `.arc TLD is native to Arc`; `.circle … Circle-aligned identities` | Use independent/non-exclusive wording; add required disclaimers. |
+| Nice | `docs/integration/wallet-integration-package.md` | `ArcNS is the naming system for Arc Testnet` | “ArcNS is an independent naming service deployed on Arc Testnet.” |
+
+## Recommended replacement copy
+
+Use the following text verbatim unless counsel/Arc/Circle provides approved alternatives:
+
+### Independent-project and trademark notice
+
+> ArcNS is an independent name service built on Arc Testnet. ArcNS is not affiliated with, endorsed by, or sponsored by Circle unless separately agreed in writing. Arc is a trademark of Circle Internet Group, Inc. and/or its affiliates.
+
+### `.circle` namespace notice
+
+> `.circle` is an ArcNS testnet namespace and does not imply Circle endorsement, sponsorship, affiliation, or ownership.
+
+### Registration lifecycle notice
+
+> Names are ERC-721 NFTs with registration periods and renewal requirements. Registration expires unless renewed before the applicable expiry date.
+
+### Accurate testnet / mainnet status
+
+> ArcNS is live on Arc Testnet for testing and demonstration. Mainnet deployment is gated on external audit, mainnet USDC configuration, operational hardening, and final legal/brand review.
+
+### Safer homepage/metadata description
+
+> ArcNS is an independent name service built on Arc Testnet. Register and resolve human-readable `.arc` and `.circle` testnet names.
+
+### Safer “Built on” line
+
+> Built on Arc Testnet. Independent project; not affiliated with, endorsed by, or sponsored by Circle unless separately agreed in writing.
+
+### Safer grant description
+
+> ArcNS is an independent naming-service project for Arc Testnet addresses. It is not an official Arc or Circle service, and proposed integrations remain subject to third-party and legal/brand review.
+
+## Non-goals / kept intentionally
+
+- **ArcNS / Arc Name Service naming remains intentionally unchanged.** It is tied to the project identity and domain. This report recommends disclaimer, attribution, and claim-control mitigations rather than a primary rename recommendation.
+- `https://arcname.services` is the canonical site reviewed. `https://arcname.service` was not used as canonical because it may be inactive or a typo.
+- This audit does not alter or evaluate tokenomics, DAO governance, ARCNS token work, private keys, secrets, contract deployment authority, or local-only tokenomics/governance branches.
+- This report does not grant legal permission to use Arc/Circle marks or make affiliation claims.
+
+## Branch recommendation
+
+Remain on the current non-tokenomics/non-governance working branch for brand/legal remediation. Create a narrowly scoped follow-up branch from the reviewed baseline (for example, `chore/arc-brand-legal-copy`) containing only the report, copy, legal-page, metadata, footer, asset-inventory, and approved-brand-asset changes. Do not merge brand work with tokenomics, DAO governance, or local-only ARCNS token changes. Obtain written Arc/Circle brand/legal review before publishing any official-asset or partner claim.
+
+## Final go / no-go for mainnet brand readiness
+
+**NO-GO.** The product should not make a public mainnet brand/legal launch until B-01, B-02, L-01, C-01, and any applicable A-01 approval are closed, and until the independently documented technical gates are also met. Testnet operation and an honestly labeled demo/grant review may continue after the Should-fix copy corrections and prominent disclosures are completed.

--- a/docs/design/frontend-runtime-model.md
+++ b/docs/design/frontend-runtime-model.md
@@ -20,7 +20,7 @@ graph TD
     end
 
     subgraph "Read Authority"
-        PRC[Primary Public Client\nArc Official RPC\nhttps://rpc.testnet.arc.network]
+        PRC[Primary Public Client\nArc Testnet RPC\nhttps://rpc.testnet.arc.network]
         FB[Fallback Chain\nBlockdaemon RPC → QuickNode RPC]
     end
 

--- a/docs/final/DEPLOYED_ADDRESSES.md
+++ b/docs/final/DEPLOYED_ADDRESSES.md
@@ -76,7 +76,7 @@
 
 ---
 
-## Production App
+## Public Testnet App
 
 | Field | Value |
 |-------|-------|

--- a/docs/final/FINAL_STATUS.md
+++ b/docs/final/FINAL_STATUS.md
@@ -3,16 +3,16 @@
 **Date:** 2026-05-09  
 **Network:** Arc Testnet (Chain ID: 5042002)  
 **Version:** v3  
-**Production App:** https://arcname.services
+**Public Testnet App:** https://arcname.services
 **Previous Vercel URL (legacy):** https://arcns-app.vercel.app
 
 ---
 
 ## Current Status: Live on Arc Testnet · Demo-Ready · Pre-Mainnet
 
-ArcNS is fully deployed and operational on Arc Testnet. The production frontend is live at https://arcname.services. Core registration, renewal, resolution, and primary-name flows are working end-to-end.
+ArcNS is fully deployed and operational on Arc Testnet. The live testnet frontend is available at https://arcname.services. Core registration, renewal, resolution, and primary-name flows are working end-to-end.
 
-This is a testnet deployment. No real funds are at risk. ArcNS is not a financial product. Mainnet deployment is gated on an external security audit and operational hardening.
+This is a testnet deployment. No real funds are at risk. ArcNS is not a financial product. Mainnet deployment is gated on external audit, mainnet USDC configuration, operational hardening, and final legal/brand review.
 
 ---
 

--- a/docs/final/FOUNDER_DEMO_SCRIPT.md
+++ b/docs/final/FOUNDER_DEMO_SCRIPT.md
@@ -1,6 +1,6 @@
 # ArcNS — Founder Demo Script
 
-**App:** https://arcns-app.vercel.app  
+**Public testnet app:** https://arcname.services
 **Network:** Arc Testnet (Chain ID: 5042002)  
 **Demo names:** `flowpay.arc`, `thebstoftimes.arc`, `slippage.arc`, `emperor.arc`
 
@@ -12,18 +12,18 @@ Before starting:
 
 - [ ] MetaMask connected to Arc Testnet (Chain ID 5042002)
 - [ ] Wallet has USDC balance (get from https://faucet.circle.com)
-- [ ] Browser tab open at https://arcns-app.vercel.app
+- [ ] Browser tab open at https://arcname.services
 - [ ] Second browser tab open at https://testnet.arcscan.app
 - [ ] Screen share ready
 
 ---
 
-## Step 1 — Home Page: The Identity Layer for Arc
+## Step 1 — Home Page: Human-Readable Names for Arc Testnet
 
-**Navigate to:** https://arcns-app.vercel.app
+**Navigate to:** https://arcname.services
 
 **Say:**
-> "This is ArcNS — the naming protocol for Arc. Instead of sharing a 42-character wallet address, you register a human-readable name like `flowpay.arc` or `alice.circle`. The name is yours as an NFT, paid for in USDC, and resolves entirely on-chain."
+> "This is ArcNS — an independent name service built on Arc Testnet. Instead of sharing a 42-character wallet address, you can register a human-readable testnet name like `flowpay.arc` or `alice.circle` for a selected registration period, pay in testnet USDC, and resolve it on-chain."
 
 **Point out:**
 - The search bar with `.arc` / `.circle` TLD selector
@@ -122,14 +122,14 @@ Before starting:
 
 ---
 
-## Step 8 — Circle Alignment
+## Step 8 — USDC Integration and Independent-Project Notice
 
 **Say:**
-> "ArcNS is built on Circle's infrastructure. Registration and renewal fees are paid in USDC. The `.circle` TLD is a first-class namespace — `alice.circle` is as valid as `alice.arc`. We're applying to the Circle 2026 Cohort 2 grant to accelerate ecosystem integrations and mainnet preparation."
+> "ArcNS uses testnet USDC for registration and renewal fees. ArcNS is an independent project and is not affiliated with, endorsed by, or sponsored by Circle unless separately agreed in writing. `.circle` is an ArcNS testnet namespace and does not imply Circle endorsement, sponsorship, affiliation, or ownership."
 
 **Key points:**
 - USDC-native from day one
-- `.circle` TLD as a dedicated namespace
+- `.circle` is an ArcNS testnet namespace with no Circle endorsement or ownership claim
 - Planned: USDC payment flows for dApps using ArcNS names
 - Planned: Circle Programmable Wallets integration for seamless onboarding
 

--- a/docs/final/MAINNET_GAP_REPORT.md
+++ b/docs/final/MAINNET_GAP_REPORT.md
@@ -23,7 +23,7 @@ This document is an honest, prioritized analysis of what must be completed befor
 | UUPS storage layout verification in CI | ❌ Not done | **P2 — Recommended** |
 | Ecosystem integrations (ArcScan, wallets) | ❌ Not started | **P3 — Nice to have** |
 | Reserved names policy | ❌ Not defined | **P3 — Nice to have** |
-| Legal / branding review | ❌ Not done | **P3 — Nice to have** |
+| Legal / branding review | ❌ Not done | **P0 — Blocker** |
 
 ---
 
@@ -105,7 +105,7 @@ This document is an honest, prioritized analysis of what must be completed befor
 ### Legal / Branding Review
 
 **What:** Legal review of the ArcNS name and branding. Review of terms of service and privacy policy.  
-**Why:** Required for a production product.
+**Why:** Required before a public mainnet launch.
 
 ---
 
@@ -120,7 +120,7 @@ This document is an honest, prioritized analysis of what must be completed befor
 | All deployer EOA privileges revoked | ✅ Done |
 | Internal security review | ✅ Done |
 | Audit preparation package | ✅ Done |
-| Production frontend deployed | ✅ Done |
+| Public testnet frontend deployed | ✅ Done |
 | Subgraph published | ✅ Done |
 | Integration packages ready | ✅ Done |
 

--- a/docs/final/RELEASE_SUMMARY.md
+++ b/docs/final/RELEASE_SUMMARY.md
@@ -4,7 +4,7 @@
 **Network:** Arc Testnet (Chain ID: 5042002)  
 **Initial Deployment:** 2026-04-24  
 **Security Migration:** 2026-04-29  
-**Production App:** https://arcname.services
+**Public Testnet App:** https://arcname.services
 **Previous Vercel URL (legacy):** https://arcns-app.vercel.app
 
 ---
@@ -32,12 +32,12 @@ All 8 v3 contracts are deployed and operational:
 
 ### Frontend
 
-- Production app live at https://arcname.services
+- Public testnet app live at https://arcname.services
 - Pages: Home/Search, My Domains (portfolio + history + primary name), Resolve
 - Indexed data reads use Goldsky as primary, The Graph Studio as fallback, with RPC fallback preserved
 - Public resolution API: `/api/v1/resolve/name/{name}`, `/api/v1/resolve/address/{address}`
 
-> Historical note: earlier release/deployment material referenced `https://arcns-app.vercel.app`. The current official production domain is `https://arcname.services`.
+> Historical note: earlier release/deployment material referenced `https://arcns-app.vercel.app`. The current canonical public testnet domain is `https://arcname.services`.
 
 ### Indexed Data Layer
 

--- a/docs/grants/CIRCLE_GRANT_README.md
+++ b/docs/grants/CIRCLE_GRANT_README.md
@@ -1,6 +1,8 @@
 # ArcNS — Circle 2026 Cohort 2 Grant Application
 
-**One-line summary:** ArcNS is a USDC-native decentralized naming protocol for Arc — it maps human-readable `.arc` and `.circle` names to on-chain addresses, issued as ERC-721 NFTs, paid for in USDC.
+**One-line summary:** ArcNS is an independent decentralized naming protocol deployed on Arc Testnet — it maps human-readable `.arc` and `.circle` testnet names to on-chain addresses, issued as ERC-721 NFTs for selected registration periods and paid for in testnet USDC.
+
+ArcNS is not an official Arc or Circle service and is not affiliated with, endorsed by, or sponsored by Circle unless separately agreed in writing. Arc is a trademark of Circle Internet Group, Inc. and/or its affiliates. `.circle` is an ArcNS testnet namespace and does not imply Circle endorsement, sponsorship, affiliation, or ownership.
 
 ---
 
@@ -8,7 +10,7 @@
 
 Wallet addresses are 42-character hex strings. They are impossible to remember, easy to mistype, and create friction for every on-chain interaction. This friction is a barrier to adoption — especially for users new to crypto.
 
-Existing naming solutions (ENS, Unstoppable Domains) are built for Ethereum and do not natively support Arc. Arc users have no human-readable identity layer.
+Existing naming solutions may not currently support Arc Testnet directly. Arc Testnet users can benefit from optional human-readable address resolution.
 
 ---
 
@@ -26,7 +28,7 @@ ArcNS provides a naming protocol purpose-built for Arc:
 
 ## Why Arc
 
-Arc is a high-performance EVM-compatible chain with a growing ecosystem. ArcNS is the identity layer that Arc needs to make addresses human-readable. The `.arc` TLD is native to Arc. The `.circle` TLD is a dedicated namespace for Circle-aligned use cases.
+Arc is a high-performance EVM-compatible chain with a growing ecosystem. ArcNS independently tests human-readable address resolution on Arc Testnet through ArcNS-operated `.arc` and `.circle` testnet namespaces.
 
 ---
 
@@ -35,7 +37,7 @@ Arc is a high-performance EVM-compatible chain with a growing ecosystem. ArcNS i
 ArcNS is USDC-native from day one:
 
 - All registration and renewal fees are paid in USDC
-- The `.circle` TLD is a first-class namespace for Circle-aligned identities
+- The `.circle` testnet namespace is operated by ArcNS and carries no Circle endorsement or ownership claim
 - The protocol is designed to integrate with Circle's payment infrastructure
 - Planned: USDC payment flows for dApps using ArcNS names as payment identifiers
 - Planned: Circle Programmable Wallets integration for seamless onboarding
@@ -55,7 +57,7 @@ Circle's USDC is the payment token for the entire ArcNS economy. This is not a r
 | Multisig (2-of-3 Safe) | Live |
 | Timelock (48h upgrade delay) | Live |
 | Indexed data layer | Goldsky primary (`arcns-product/v0.1.0`), The Graph Studio fallback, RPC fallback preserved |
-| Production frontend | Live at https://arcname.services |
+| Public testnet frontend | Live at https://arcname.services |
 | Contract test suite | ~180 passing tests, zero failures |
 | External security audit | Not yet completed — required before mainnet |
 
@@ -79,7 +81,7 @@ Previous Vercel URL (legacy/reference): https://arcns-app.vercel.app
 
 - `contracts/v3/` — all 8 v3 contracts
 - `deployments/arc_testnet-v3.json` — canonical deployed addresses
-- `frontend/` — Next.js 14 production frontend
+- `frontend/` — Next.js 14 live testnet frontend
 - `indexer/` — indexed data mappings and manifests (Goldsky primary, The Graph Studio fallback)
 - `docs/` — full documentation
 
@@ -108,7 +110,7 @@ Full address table: [docs/final/DEPLOYED_ADDRESSES.md](../final/DEPLOYED_ADDRESS
 | Product | Integration |
 |---------|-------------|
 | USDC (Arc Testnet) | Payment token for all registrations and renewals |
-| `.circle` TLD | Dedicated namespace for Circle-aligned identities |
+| `.circle` TLD | ArcNS testnet namespace; no Circle endorsement, affiliation, sponsorship, or ownership implied |
 
 ---
 
@@ -150,7 +152,7 @@ Full address table: [docs/final/DEPLOYED_ADDRESSES.md](../final/DEPLOYED_ADDRESS
 - Proposal was submitted and is currently in review.
 - The final demo video update was posted via Questbook comments (proposal body was not editable after submission).
 - Goldsky primary indexing is now live in production on Arc Testnet.
-- ArcNS official production domain is now https://arcname.services.
+- ArcNS canonical public testnet domain is now https://arcname.services.
 - Prior submitted/grant material may still reference https://arcns-app.vercel.app.
 - ArcNS remains live on Arc Testnet (pre-mainnet, external audit pending).
 - ArcNS is listed on ArcLens under the Identity category.
@@ -169,7 +171,7 @@ See [../final/FOUNDER_DEMO_SCRIPT.md](../final/FOUNDER_DEMO_SCRIPT.md) for the f
 4. Resolve — forward resolution and identity inspection
 5. `thebstoftimes.arc` — registered name with no address record (demonstrates correctness)
 6. ArcScan — verified contracts
-7. Circle alignment — USDC-native, `.circle` TLD, planned integrations
+7. Independent-project disclosure — testnet USDC, `.circle` namespace disclaimer, planned integrations
 
 ---
 

--- a/docs/grants/INVESTOR_DECK_OUTLINE.md
+++ b/docs/grants/INVESTOR_DECK_OUTLINE.md
@@ -6,10 +6,10 @@
 
 ## Slide 1 — Title
 
-**Title:** ArcNS — The Identity Layer for Arc  
-**Subtitle:** Human-readable names for Arc addresses, paid in USDC  
-**Visual:** ArcNS logo + Arc Testnet badge  
-**Footer:** https://arcns-app.vercel.app · Arc Testnet · Pre-mainnet
+**Title:** ArcNS — Independent Naming on Arc Testnet
+**Subtitle:** Human-readable testnet names for Arc addresses, paid in testnet USDC
+**Visual:** ArcNS logo + Arc Testnet badge
+**Footer:** https://arcname.services · Arc Testnet · Pre-mainnet · Independent project
 
 ---
 
@@ -21,7 +21,7 @@
 - `0x0b943Fe9f1f8135e0751BA8B43dc0cD688ad209D` — this is what users share today
 - 42 characters. Impossible to remember. Easy to mistype. Zero identity signal.
 - Every on-chain interaction requires copy-pasting an address
-- No naming solution exists natively for Arc
+- Arc Testnet users need an optional human-readable naming service
 
 **Visual:** Side-by-side: hex address vs `alice.arc`
 
@@ -48,13 +48,13 @@
 
 **Why Arc:**
 - Arc is a high-performance EVM chain with a growing ecosystem
-- ArcNS is the identity layer Arc needs
-- `.arc` TLD is native to Arc
+- ArcNS is an independent naming-service project for Arc Testnet addresses
+- `.arc` is an ArcNS testnet namespace
 - First mover — no competing naming protocol on Arc
 
 **Why Circle:**
 - USDC is the payment token for the entire ArcNS economy — from day one
-- `.circle` TLD is a dedicated namespace for Circle-aligned identities
+- `.circle` is an ArcNS testnet namespace and does not imply Circle endorsement, sponsorship, affiliation, or ownership
 - Planned: Circle Programmable Wallets integration
 - Planned: USDC payment routing via ArcNS names
 - ArcNS makes USDC more useful by giving addresses human-readable identities
@@ -63,7 +63,7 @@
 
 ## Slide 5 — Product Demo
 
-**Headline:** Live on Arc Testnet at arcns-app.vercel.app
+**Headline:** Live on Arc Testnet at arcname.services
 
 **Screenshots / flow:**
 1. Home page — search bar with `.arc` / `.circle` TLD selector
@@ -73,7 +73,7 @@
 
 **Key callout:** "Everything resolves on-chain. No off-chain infrastructure required."
 
-**Link:** https://arcns-app.vercel.app
+**Link:** https://arcname.services
 
 ---
 
@@ -105,7 +105,7 @@
 | Governance | 2-of-3 Safe + 48h Timelock |
 | Contract tests | ~180 passing, 0 failures |
 | Smoke tests | 10 flows verified on-chain |
-| Production frontend | Live at arcns-app.vercel.app |
+| Public testnet frontend | Live at arcname.services |
 | Subgraph | Live on The Graph Studio |
 | External audit | Not yet completed — required before mainnet |
 
@@ -153,16 +153,16 @@
 
 ## Slide 10 — Vision
 
-**Headline:** ArcNS is the identity layer for the Arc ecosystem
+**Headline:** A proposed independent naming service for Arc Testnet users
 
 **Vision:**
 - Every Arc address has a human-readable name
 - Every USDC payment on Arc can be addressed by name
-- ArcNS names are the primary identity primitive for Arc dApps, wallets, and explorers
-- The `.circle` namespace becomes the standard identity for Circle-aligned users on Arc
+- ArcNS names could provide an optional naming primitive for compatible dApps, wallets, and explorers
+- The `.circle` testnet namespace remains non-official and subject to legal/brand review
 
 **Why now:**
-- Arc is growing. The identity layer needs to be in place before the ecosystem scales.
+- Arc is growing, creating an opportunity to test optional human-readable naming infrastructure.
 - USDC adoption on Arc is accelerating. ArcNS makes USDC payments more human.
 - First mover advantage — no competing naming protocol on Arc.
 
@@ -174,7 +174,7 @@
 
 | Document | Link |
 |----------|------|
-| Live app | https://arcns-app.vercel.app |
+| Live testnet app | https://arcname.services |
 | GitHub | https://github.com/khenzarr/arcns |
 | Demo video script | [DEMO_VIDEO_SCRIPT.md](DEMO_VIDEO_SCRIPT.md) |
 | Deployed addresses | [docs/final/DEPLOYED_ADDRESSES.md](../final/DEPLOYED_ADDRESSES.md) |

--- a/docs/integration/GOLDSKY_ARCNS_INTEGRATION_PLAN.md
+++ b/docs/integration/GOLDSKY_ARCNS_INTEGRATION_PLAN.md
@@ -185,7 +185,7 @@ Do **not** change logic now. Later, after parity:
 
 - Deploy **indexer/** subgraph to Goldsky without touching frontend config.
 - Optionally deploy `bens-subgraph/` to Goldsky for parallel observability.
-- Keep The Graph endpoint active for production frontend.
+- Keep The Graph endpoint active as a live testnet frontend fallback.
 
 ## Phase 2 — Endpoint parity tests (old vs Goldsky)
 

--- a/docs/integration/wallet-integration-package.md
+++ b/docs/integration/wallet-integration-package.md
@@ -22,7 +22,7 @@ ArcNS maps human-readable names ending in `.arc` or `.circle` to EVM addresses o
 
 Raw EVM addresses are 42-character hex strings. They are error-prone to type, hard to verify visually, and meaningless to most users. Name resolution at the wallet layer is the highest-leverage integration point in the ecosystem — it is where users spend the most time and where address errors cause the most harm.
 
-ArcNS is the naming system for Arc Testnet. Wallet support is the primary mechanism by which ArcNS names become useful to end users in practice. Without it, names are only visible inside the ArcNS app itself.
+ArcNS is an independent naming service deployed on Arc Testnet. Wallet support is a mechanism by which ArcNS names could become useful to end users in practice. Without it, names are only visible inside the ArcNS app itself.
 
 ### What is already available vs what wallets must consume
 

--- a/docs/release/RELEASE_CHECKLIST.md
+++ b/docs/release/RELEASE_CHECKLIST.md
@@ -113,7 +113,7 @@ Run after every contract deploy (or when addresses change).
   - `NEXT_PUBLIC_SUBGRAPH_URL`
   - `NEXT_PUBLIC_RPC_URL`
   - `NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID`
-- [ ] Verify production app at https://arcns-app.vercel.app
+- [ ] Verify public testnet app at https://arcname.services
 
 ---
 

--- a/docs/release/RUNBOOK.md
+++ b/docs/release/RUNBOOK.md
@@ -202,8 +202,8 @@ cd frontend && npm run build
 **When:** After every production deployment.
 
 ```bash
-# 1. Verify production app is live
-curl -I https://arcns-app.vercel.app
+# 1. Verify public testnet app is live
+curl -I https://arcname.services
 
 # 2. Verify resolution API is responding
 curl https://arcns-app.vercel.app/api/v1/health

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -16,7 +16,9 @@ const spaceGrotesk = Space_Grotesk({
 export const metadata: Metadata = {
   title: "ArcNS — Arc Name Service",
   description:
-    "Decentralized naming service for Arc Testnet. Register .arc and .circle domains.",
+    "ArcNS is an independent name service built on Arc Testnet. Register and resolve human-readable .arc and .circle testnet names.",
+  metadataBase: new URL("https://arcname.services"),
+  alternates: { canonical: "/" },
   icons: { icon: "/icon.svg" },
 };
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -24,7 +24,7 @@ const TRUST_ITEMS = [
   },
   {
     title: "Pay with USDC",
-    sub: "Secure. Stable. On-chain.",
+    sub: "Testnet USDC. On-chain.",
     accent: "#3BA3FF",
     icon: (
       <svg viewBox="0 0 28 28" fill="none" aria-hidden="true">
@@ -60,7 +60,7 @@ const TRUST_ITEMS = [
 const FEATURES = [
   {
     title: "NFT Ownership",
-    desc: "Each name is an ERC-721 NFT. Transfer, sell, or hold forever.",
+    desc: "ERC-721 ownership for the selected registration period. Renew before expiry.",
     accent: "var(--arcns-cyan)",
     icon: TRUST_ITEMS[2].icon,
   },
@@ -121,14 +121,18 @@ export default function HomePage() {
             </div>
 
             <h1 className="arcns-hero-headline">
-              Your identity <span className="arcns-gradient-text">on Arc</span>
+              Human-readable names <span className="arcns-gradient-text">on Arc Testnet</span>
             </h1>
 
             <p className="arcns-hero-subtitle">
               Register <strong>.arc</strong> and <strong className="circle">.circle</strong> names.
               Pay with <span>USDC</span>.
               <br />
-              Own your on-chain identity as an NFT.
+              Receive an ERC-721 name NFT for your selected registration period.
+            </p>
+            <p className="mt-4 max-w-2xl text-sm leading-6 text-[var(--arcns-text-secondary)]">
+              ArcNS is an independent name service built on Arc Testnet. <strong>.circle</strong> is an
+              ArcNS testnet namespace and does not imply Circle endorsement, sponsorship, affiliation, or ownership.
             </p>
           </div>
 

--- a/frontend/src/app/privacy/page.tsx
+++ b/frontend/src/app/privacy/page.tsx
@@ -1,0 +1,61 @@
+import type { Metadata } from "next";
+import LegalPage, {
+  CIRCLE_NAMESPACE_NOTICE,
+  INDEPENDENT_PROJECT_NOTICE,
+  TESTNET_STATUS_NOTICE,
+} from "../../components/LegalPage";
+
+export const metadata: Metadata = { title: "Privacy Policy | ArcNS" };
+
+export default function PrivacyPage() {
+  return (
+    <LegalPage
+      title="Privacy Policy"
+      summary="This policy explains the information involved when you use the public ArcNS testnet app. Public blockchain activity is inherently visible and should not be treated as private."
+      sections={[
+        {
+          title: "Current service status",
+          content: <p>{TESTNET_STATUS_NOTICE}</p>,
+        },
+        {
+          title: "Information processed",
+          content: (
+            <p>
+              The app may process wallet addresses, name-search input, network information, and transaction data
+              needed to display and submit testnet interactions. Wallet and name records written to Arc Testnet
+              are public blockchain data and may be indexed or retained by independent infrastructure providers.
+            </p>
+          ),
+        },
+        {
+          title: "Infrastructure and third parties",
+          content: (
+            <p>
+              The app may rely on wallet providers, RPC endpoints, indexers, hosting services, and public blockchain
+              explorers. Those independent services may process technical data under their own policies. ArcNS
+              makes no promise that testnet infrastructure will remain available or that a mainnet service will launch.
+            </p>
+          ),
+        },
+        {
+          title: "No financial or legal promise",
+          content: (
+            <p>
+              This policy does not create a financial guarantee, legal representation, fiduciary relationship, or
+              promise concerning the value, permanence, availability, or future portability of any testnet name.
+            </p>
+          ),
+        },
+        {
+          title: "Independent project notice",
+          content: (
+            <>
+              <p>{INDEPENDENT_PROJECT_NOTICE}</p>
+              <p>{CIRCLE_NAMESPACE_NOTICE}</p>
+            </>
+          ),
+        },
+      ]}
+    />
+  );
+}

--- a/frontend/src/app/terms/page.tsx
+++ b/frontend/src/app/terms/page.tsx
@@ -1,0 +1,57 @@
+import type { Metadata } from "next";
+import LegalPage, {
+  CIRCLE_NAMESPACE_NOTICE,
+  INDEPENDENT_PROJECT_NOTICE,
+  REGISTRATION_NOTICE,
+  TESTNET_STATUS_NOTICE,
+} from "../../components/LegalPage";
+
+export const metadata: Metadata = { title: "Terms of Use | ArcNS" };
+
+export default function TermsPage() {
+  return (
+    <LegalPage
+      title="Terms of Use"
+      summary="These terms describe the limited, testnet-only basis on which ArcNS is currently made available. They are informational project terms and are not legal advice."
+      sections={[
+        {
+          title: "Testnet service and launch status",
+          content: <p>{TESTNET_STATUS_NOTICE}</p>,
+        },
+        {
+          title: "No promises or professional advice",
+          content: (
+            <p>
+              ArcNS is provided on an experimental, as-is, and as-available basis. Nothing in the app or
+              documentation is a promise of mainnet or public launch, financial return, continued availability,
+              legal outcome, or fitness for a particular purpose. ArcNS does not provide financial, investment,
+              tax, or legal advice.
+            </p>
+          ),
+        },
+        {
+          title: "Name registration and renewal",
+          content: (
+            <>
+              <p>{REGISTRATION_NOTICE}</p>
+              <p>
+                Users are responsible for checking the selected registration period, applicable expiry date,
+                renewal status, wallet transactions, and testnet conditions. Testnet names and records may not
+                carry over to any future deployment.
+              </p>
+            </>
+          ),
+        },
+        {
+          title: "Independent project and trademarks",
+          content: (
+            <>
+              <p>{INDEPENDENT_PROJECT_NOTICE}</p>
+              <p>{CIRCLE_NAMESPACE_NOTICE}</p>
+            </>
+          ),
+        },
+      ]}
+    />
+  );
+}

--- a/frontend/src/app/trademark/page.tsx
+++ b/frontend/src/app/trademark/page.tsx
@@ -1,0 +1,49 @@
+import type { Metadata } from "next";
+import LegalPage, {
+  CIRCLE_NAMESPACE_NOTICE,
+  INDEPENDENT_PROJECT_NOTICE,
+  TESTNET_STATUS_NOTICE,
+} from "../../components/LegalPage";
+
+export const metadata: Metadata = { title: "Trademark / Brand Notice | ArcNS" };
+
+export default function TrademarkPage() {
+  return (
+    <LegalPage
+      title="Trademark / Brand Notice"
+      summary="This notice distinguishes the independent ArcNS project from third-party Arc and Circle brands and does not grant permission to use any party’s marks."
+      sections={[
+        {
+          title: "Arc and Circle attribution",
+          content: <p>{INDEPENDENT_PROJECT_NOTICE}</p>,
+        },
+        {
+          title: ".circle testnet namespace",
+          content: <p>{CIRCLE_NAMESPACE_NOTICE}</p>,
+        },
+        {
+          title: "No ownership or endorsement claim",
+          content: (
+            <p>
+              The ArcNS project claims no ownership of the Arc or Circle names, marks, logos, or other brand assets.
+              References to Arc Testnet and Circle are descriptive only and do not state or imply partnership,
+              approval, endorsement, sponsorship, or official status.
+            </p>
+          ),
+        },
+        {
+          title: "Testnet status and no promises",
+          content: (
+            <>
+              <p>{TESTNET_STATUS_NOTICE}</p>
+              <p>
+                Nothing in ArcNS branding is a promise of mainnet launch, financial value, legal right, continued
+                availability, or future recognition of a testnet name.
+              </p>
+            </>
+          ),
+        },
+      ]}
+    />
+  );
+}

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -23,7 +23,7 @@ const FOOTER_SECTIONS: FooterSection[] = [
       { label: "Search Names", href: "/" },
       { label: "My Domains", href: "/my-domains" },
       { label: "Resolve", href: "/resolve" },
-      { label: "Official Domain", href: "https://arcname.services", external: true },
+      { label: "Public Testnet App", href: "https://arcname.services", external: true },
       { label: "GitHub", href: GITHUB_REPO, external: true },
     ],
   },
@@ -107,10 +107,9 @@ const FOOTER_SECTIONS: FooterSection[] = [
   {
     title: "Legal / Brand",
     links: [
-      { label: "Privacy Policy", disabled: true, note: "Coming soon" },
-      { label: "Terms of Use", disabled: true, note: "Coming soon" },
-      { label: "Trademark Guidelines", disabled: true, note: "Coming soon" },
-      { label: "Brand Kit", disabled: true, note: "Coming soon" },
+      { label: "Terms of Use", href: "/terms" },
+      { label: "Privacy Policy", href: "/privacy" },
+      { label: "Trademark / Brand Notice", href: "/trademark" },
     ],
   },
 ];
@@ -193,7 +192,7 @@ export default function Footer() {
                     ArcNS
                   </p>
                   <p className="text-sm text-[var(--arcns-text-secondary)]">
-                    Human-readable identity for Arc.
+                    Human-readable names for Arc Testnet addresses.
                   </p>
                 </div>
               </div>
@@ -207,8 +206,11 @@ export default function Footer() {
               <div className="space-y-2 text-sm leading-6 text-[var(--arcns-text-secondary)]">
                 <p>Live on Arc Testnet · Pre-mainnet · External audit pending</p>
                 <p className="max-w-xl text-[13px] text-[var(--arcns-text-muted)]">
-                  ArcNS is an Arc Testnet naming and identity protocol. Mainnet deployment is gated on
-                  security review and operational hardening.
+                  ArcNS is an independent name service built on Arc Testnet. ArcNS is not affiliated with,
+                  endorsed by, or sponsored by Circle unless separately agreed in writing.
+                </p>
+                <p className="max-w-xl text-[13px] text-[var(--arcns-text-muted)]">
+                  Arc is a trademark of Circle Internet Group, Inc. and/or its affiliates.
                 </p>
               </div>
             </div>

--- a/frontend/src/components/LegalPage.tsx
+++ b/frontend/src/components/LegalPage.tsx
@@ -1,0 +1,61 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+type LegalSection = {
+  title: string;
+  content: ReactNode;
+};
+
+export const INDEPENDENT_PROJECT_NOTICE =
+  "ArcNS is an independent name service built on Arc Testnet. ArcNS is not affiliated with, endorsed by, or sponsored by Circle unless separately agreed in writing. Arc is a trademark of Circle Internet Group, Inc. and/or its affiliates.";
+
+export const CIRCLE_NAMESPACE_NOTICE =
+  "`.circle` is an ArcNS testnet namespace and does not imply Circle endorsement, sponsorship, affiliation, or ownership.";
+
+export const REGISTRATION_NOTICE =
+  "Names are ERC-721 NFTs with registration periods and renewal requirements. Registration expires unless renewed before the applicable expiry date.";
+
+export const TESTNET_STATUS_NOTICE =
+  "ArcNS is live on Arc Testnet for testing and demonstration. Mainnet deployment is gated on external audit, mainnet USDC configuration, operational hardening, and final legal/brand review.";
+
+export default function LegalPage({
+  title,
+  summary,
+  sections,
+}: {
+  title: string;
+  summary: string;
+  sections: LegalSection[];
+}) {
+  return (
+    <div className="mx-auto w-full max-w-4xl px-4 py-12 sm:px-6 lg:px-8 lg:py-16">
+      <article className="arcns-glass rounded-[28px] border border-[var(--arcns-border-default)] px-6 py-8 text-[var(--arcns-text-secondary)] shadow-[0_24px_80px_rgba(0,0,0,0.24)] sm:px-10 sm:py-12">
+        <p className="mb-3 text-xs font-semibold uppercase tracking-[0.22em] text-[var(--arcns-cyan)]">
+          Legal / Brand
+        </p>
+        <h1 className="font-space-grotesk text-3xl font-bold tracking-[-0.04em] text-[var(--arcns-text-primary)] sm:text-4xl">
+          {title}
+        </h1>
+        <p className="mt-4 leading-7">{summary}</p>
+        <p className="mt-3 text-sm text-[var(--arcns-text-muted)]">Last updated: August 1, 2026</p>
+
+        <div className="mt-10 space-y-9">
+          {sections.map(section => (
+            <section key={section.title}>
+              <h2 className="font-space-grotesk text-xl font-semibold text-[var(--arcns-text-primary)]">
+                {section.title}
+              </h2>
+              <div className="mt-3 space-y-3 leading-7">{section.content}</div>
+            </section>
+          ))}
+        </div>
+
+        <div className="mt-10 border-t border-white/10 pt-6 text-sm">
+          <Link className="text-[var(--arcns-cyan)] hover:underline" href="/">
+            Return to ArcNS
+          </Link>
+        </div>
+      </article>
+    </div>
+  );
+}

--- a/frontend/src/lib/chains.ts
+++ b/frontend/src/lib/chains.ts
@@ -6,7 +6,7 @@ export const ARC_TESTNET_RUNTIME_MODE = "arc-testnet" as const;
 export const ARC_TESTNET_RPCS = {
   primary: {
     key: "primary",
-    name: "Arc Official RPC",
+    name: "Arc Testnet RPC",
     url: process.env.NEXT_PUBLIC_RPC_URL ?? "https://rpc.testnet.arc.network",
   },
   secondary: [

--- a/frontend/src/lib/wagmiConfig.ts
+++ b/frontend/src/lib/wagmiConfig.ts
@@ -20,9 +20,9 @@ export const wagmiConfig = createConfig({
       projectId: process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID || "b6d7afb94938b1fd9d9a72f7364fb905",
       metadata: {
         name: "Arc Name Service",
-        description: "Decentralized naming on Arc Testnet",
-        url: "https://arcns.app",
-        icons: ["https://arcns.app/favicon.ico"],
+        description: "Independent name service built on Arc Testnet",
+        url: "https://arcname.services",
+        icons: ["https://arcname.services/icon.svg"],
       },
       showQrModal: true,
     }),


### PR DESCRIPTION
This PR applies ArcNS brand/legal copy remediation before mainnet readiness work.

Changes include:
- Adds Terms of Use, Privacy Policy, and Trademark / Brand Notice pages.
- Adds independent-project and Arc/Circle trademark attribution language.
- Updates footer legal links and disclaimer.
- Replaces misleading registration lifecycle wording with registration-period / renewal language.
- Removes or softens official, identity-layer, native, production, and unqualified secure claims.
- Updates canonical WalletConnect metadata to arcname.services.
- Updates public docs to consistently describe ArcNS as a public Arc Testnet / pre-mainnet service.
- Includes the ArcNS Arc brand guideline audit report.

Out of scope:
- No tokenomics / DAO governance work.
- No contract changes.
- No pricing changes.
- No deployment or on-chain action.