### PR TITLE
feat: prepare Arc mainnet pricing and early-adopter discount

### DIFF
--- a/contracts/v3/controller/ArcNSController.sol
+++ b/contracts/v3/controller/ArcNSController.sol
@@ -13,6 +13,8 @@ import "../interfaces/IArcNSRegistry.sol";
 import "../interfaces/IArcNSResolver.sol";
 import "../interfaces/IArcNSReverseRegistrar.sol";
 import "../interfaces/IArcNSController.sol";
+import "../discount/IArcNSEarlyAdopterDiscountRegistry.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
 
 /// @title ArcNSController
 /// @notice Orchestrates commit-reveal registration and renewal for ArcNS names
@@ -70,6 +72,9 @@ contract ArcNSController is
     /// @param maxCost The caller's maximum acceptable cost
     error PriceExceedsMaxCost(uint256 price, uint256 maxCost);
 
+    error DiscountRegistryNotConfigured();
+    error DiscountOwnerMustBeSender();
+
     // ─── Events ───────────────────────────────────────────────────────────────
 
     /// @notice Emitted when a name is successfully registered
@@ -92,6 +97,8 @@ contract ArcNSController is
 
     /// @notice Emitted when the reverseRegistrar address is updated
     event ReverseRegistrarUpdated(address indexed oldReverseRegistrar, address indexed newReverseRegistrar);
+
+    event DiscountRegistryUpdated(address indexed oldRegistry, address indexed newRegistry);
 
     // ─── Roles ────────────────────────────────────────────────────────────────
 
@@ -118,6 +125,8 @@ contract ArcNSController is
     /// @notice Maximum time a commitment remains valid (24 hours)
     uint256 public constant MAX_COMMITMENT_AGE = 24 hours;
 
+    uint256 private constant ONE_YEAR = 365 days;
+
     // ─── Storage layout (CRITICAL — do not reorder) ───────────────────────────
     //
     // Inherited slots: Initializable, AccessControlUpgradeable, PausableUpgradeable, UUPSUpgradeable
@@ -134,7 +143,8 @@ contract ArcNSController is
     // Slot N+8:  commitments                (mapping bytes32 => uint256)
     // Slot N+9:  usedCommitments            (mapping bytes32 => bool)
     // Slot N+10: approvedResolvers          (mapping address => bool)
-    // Slots N+11 to N+60: __gap[50]         (reserved for future fields)
+    // Slot N+11: discountRegistry
+    // Slots N+12 to N+60: __gap[49]         (reserved for future fields)
 
     /// @dev Storage-based reentrancy guard status
     uint256 private _reentrancyStatus;
@@ -172,8 +182,11 @@ contract ArcNSController is
     /// @notice Admin-controlled allowlist of approved resolver addresses
     mapping(address => bool)    public approvedResolvers;
 
-    /// @dev Reserved storage gap for future fields (50 slots)
-    uint256[50] private __gap;
+    /// @notice Shared one-time discount registry used by both TLD controllers
+    IArcNSEarlyAdopterDiscountRegistry public discountRegistry;
+
+    /// @dev Reserved storage gap for future fields (49 slots)
+    uint256[49] private __gap;
 
     // ─── Reentrancy guard ─────────────────────────────────────────────────────
 
@@ -355,6 +368,53 @@ contract ArcNSController is
         emit NameRegistered(name_, label, owner_, cost, expires);
     }
 
+    /// @notice Registers with the shared, one-time active-v3-holder discount.
+    /// @dev Uses the normal sender-bound commitment. Registry consumption and registration
+    ///      are atomic, so a later revert restores the wallet's unused state.
+    function registerWithDiscount(
+        string calldata name_,
+        address owner_,
+        uint256 duration,
+        bytes32 secret,
+        address resolverAddr,
+        bool reverseRecord,
+        uint256 maxCost,
+        bytes32[] calldata proof
+    ) external override nonReentrant whenNotPaused {
+        if (owner_ != msg.sender) revert DiscountOwnerMustBeSender();
+        if (address(discountRegistry) == address(0)) revert DiscountRegistryNotConfigured();
+
+        bytes32 commitment = makeCommitment(name_, owner_, duration, secret, resolverAddr, reverseRecord, msg.sender);
+        _validateCommitment(commitment);
+        if (!_validName(name_)) revert InvalidName();
+        if (duration < MIN_REGISTRATION_DURATION) revert DurationTooShort();
+        if (resolverAddr != address(0) && !approvedResolvers[resolverAddr]) {
+            revert ResolverNotApproved(resolverAddr);
+        }
+
+        IArcNSPriceOracle.Price memory p = discountRentPrice(name_, duration);
+        uint256 cost = p.base + p.premium;
+        if (cost > maxCost) revert PriceExceedsMaxCost(cost, maxCost);
+
+        discountRegistry.consume(msg.sender, proof);
+        usdc.safeTransferFrom(msg.sender, treasury, cost);
+
+        bytes32 label = keccak256(bytes(name_));
+        uint256 tokenId = uint256(label);
+        bytes32 nodehash = keccak256(abi.encodePacked(base.baseNode(), label));
+        uint256 expires;
+        if (resolverAddr != address(0)) {
+            expires = base.registerWithResolver(tokenId, owner_, duration, resolverAddr);
+            resolver.setAddr(nodehash, owner_);
+        } else {
+            expires = base.register(tokenId, owner_, duration);
+        }
+        if (reverseRecord && resolverAddr != address(0)) {
+            try reverseRegistrar.setReverseRecord(owner_, string(abi.encodePacked(name_, ".", base.tld()))) {} catch {}
+        }
+        emit NameRegistered(name_, label, owner_, cost, expires);
+    }
+
     // ─── Renewal ──────────────────────────────────────────────────────────────
 
     /// @notice Renews an existing name
@@ -400,6 +460,26 @@ contract ArcNSController is
         bytes32 label   = keccak256(bytes(name_));
         uint256 tokenId = uint256(label);
         return priceOracle.price(name_, base.nameExpires(tokenId), duration);
+    }
+
+    /// @notice Quotes the discounted registration while preserving any expired-name premium in full.
+    function discountRentPrice(string memory name_, uint256 duration) public view override returns (IArcNSPriceOracle.Price memory) {
+        bytes32 label = keccak256(bytes(name_));
+        uint256 tokenId = uint256(label);
+        uint256 expires = base.nameExpires(tokenId);
+        IArcNSPriceOracle.Price memory fullQuote = priceOracle.price(name_, expires, duration);
+        uint256 discountedAnnual = _earlyAdopterAnnualPrice(bytes(name_).length);
+        uint256 discountedBase;
+
+        if (duration <= ONE_YEAR) {
+            discountedBase = Math.mulDiv(discountedAnnual, duration, ONE_YEAR, Math.Rounding.Ceil);
+        } else {
+            uint256 remainingDuration = duration - ONE_YEAR;
+            uint256 standardAnnual = priceOracle.price(name_, expires, ONE_YEAR).base;
+            discountedBase = discountedAnnual
+                + Math.mulDiv(standardAnnual, remainingDuration, ONE_YEAR, Math.Rounding.Ceil);
+        }
+        return IArcNSPriceOracle.Price({base: discountedBase, premium: fullQuote.premium});
     }
 
     /// @notice Returns whether a name is available for registration
@@ -458,6 +538,12 @@ contract ArcNSController is
         address old = address(reverseRegistrar);
         reverseRegistrar = IArcNSReverseRegistrar(newReverseRegistrar);
         emit ReverseRegistrarUpdated(old, newReverseRegistrar);
+    }
+
+    function setDiscountRegistry(address newDiscountRegistry) external override onlyRole(ADMIN_ROLE) {
+        address old = address(discountRegistry);
+        discountRegistry = IArcNSEarlyAdopterDiscountRegistry(newDiscountRegistry);
+        emit DiscountRegistryUpdated(old, newDiscountRegistry);
     }
 
     /// @notice Approves or revokes a resolver address
@@ -545,5 +631,13 @@ contract ArcNSController is
         if (b[0] == 0x2D || b[b.length - 1] == 0x2D) return false;  // leading/trailing hyphen
         if (b.length >= 4 && b[2] == 0x2D && b[3] == 0x2D) return false;  // double-hyphen at pos 2-3
         return true;
+    }
+
+    function _earlyAdopterAnnualPrice(uint256 len) internal pure returns (uint256) {
+        if (len == 1) return 50_000_000;
+        if (len == 2) return 25_000_000;
+        if (len == 3) return 15_000_000;
+        if (len == 4) return 10_000_000;
+        return 2_000_000;
     }
 }

--- a/contracts/v3/discount/ArcNSEarlyAdopterDiscountRegistry.sol
+++ b/contracts/v3/discount/ArcNSEarlyAdopterDiscountRegistry.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
+
+/// @title ArcNSEarlyAdopterDiscountRegistry
+/// @notice Shared, wallet-level one-time claim state for all ArcNS v3 controllers.
+contract ArcNSEarlyAdopterDiscountRegistry is Ownable {
+    error DiscountInactive();
+    error RootNotFrozen();
+    error EmptyMerkleRoot();
+    error InvalidAccount();
+    error DiscountAlreadyUsed(address account);
+    error UnauthorizedController(address controller);
+    error InvalidProof();
+    error RootAlreadyFrozen();
+
+    bytes32 public immutable campaignId;
+    uint256 public immutable snapshotBlock;
+    bytes32 public merkleRoot;
+    bool public discountActive;
+    bool public rootFrozen;
+
+    mapping(address => bool) public used;
+    mapping(address => bool) public authorizedControllers;
+
+    event DiscountRootUpdated(bytes32 indexed oldRoot, bytes32 indexed newRoot);
+    event DiscountRootFrozen(bytes32 indexed root);
+    event DiscountActiveUpdated(bool active);
+    event DiscountControllerAuthorizationUpdated(address indexed controller, bool authorized);
+    event DiscountUsed(address indexed account, address indexed controller, bytes32 indexed campaignId);
+
+    constructor(bytes32 campaignId_, uint256 snapshotBlock_, address owner_) Ownable(owner_) {
+        if (campaignId_ == bytes32(0)) revert EmptyMerkleRoot();
+        if (owner_ == address(0)) revert InvalidAccount();
+        campaignId = campaignId_;
+        snapshotBlock = snapshotBlock_;
+    }
+
+    function setMerkleRoot(bytes32 newRoot) external onlyOwner {
+        if (rootFrozen) revert RootAlreadyFrozen();
+        bytes32 oldRoot = merkleRoot;
+        merkleRoot = newRoot;
+        emit DiscountRootUpdated(oldRoot, newRoot);
+    }
+
+    function freezeRoot() external onlyOwner {
+        if (rootFrozen) revert RootAlreadyFrozen();
+        if (merkleRoot == bytes32(0)) revert EmptyMerkleRoot();
+        rootFrozen = true;
+        emit DiscountRootFrozen(merkleRoot);
+    }
+
+    function setDiscountActive(bool active) external onlyOwner {
+        discountActive = active;
+        emit DiscountActiveUpdated(active);
+    }
+
+    function setControllerAuthorization(address controller, bool authorized) external onlyOwner {
+        if (controller == address(0)) revert InvalidAccount();
+        authorizedControllers[controller] = authorized;
+        emit DiscountControllerAuthorizationUpdated(controller, authorized);
+    }
+
+    function consume(address account, bytes32[] calldata proof) external {
+        if (!authorizedControllers[msg.sender]) revert UnauthorizedController(msg.sender);
+        if (!discountActive) revert DiscountInactive();
+        if (!rootFrozen) revert RootNotFrozen();
+        bytes32 root = merkleRoot;
+        if (root == bytes32(0)) revert EmptyMerkleRoot();
+        if (account == address(0)) revert InvalidAccount();
+        if (used[account]) revert DiscountAlreadyUsed(account);
+
+        bytes32 leaf = keccak256(abi.encode(campaignId, account));
+        if (!MerkleProof.verifyCalldata(proof, root, leaf)) revert InvalidProof();
+
+        used[account] = true;
+        emit DiscountUsed(account, msg.sender, campaignId);
+    }
+}

--- a/contracts/v3/discount/IArcNSEarlyAdopterDiscountRegistry.sol
+++ b/contracts/v3/discount/IArcNSEarlyAdopterDiscountRegistry.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+interface IArcNSEarlyAdopterDiscountRegistry {
+    function consume(address account, bytes32[] calldata proof) external;
+}

--- a/contracts/v3/interfaces/IArcNSController.sol
+++ b/contracts/v3/interfaces/IArcNSController.sol
@@ -28,6 +28,19 @@ interface IArcNSController {
         uint256 maxCost
     ) external;
 
+    function registerWithDiscount(
+        string calldata name_,
+        address owner_,
+        uint256 duration,
+        bytes32 secret,
+        address resolverAddr,
+        bool reverseRecord,
+        uint256 maxCost,
+        bytes32[] calldata proof
+    ) external;
+
+    function discountRentPrice(string memory name_, uint256 duration) external view returns (IArcNSPriceOracle.Price memory);
+
     /// @notice Renews an existing name
     /// @param name_ The plaintext label to renew
     /// @param duration Additional duration in seconds
@@ -82,4 +95,6 @@ interface IArcNSController {
     ///      Rejects address(0). Emits ReverseRegistrarUpdated.
     /// @param newReverseRegistrar The new ArcNSReverseRegistrar contract address
     function setReverseRegistrar(address newReverseRegistrar) external;
+
+    function setDiscountRegistry(address newDiscountRegistry) external;
 }

--- a/docs/mainnet/DEPLOYMENT_RUNBOOK.md
+++ b/docs/mainnet/DEPLOYMENT_RUNBOOK.md
@@ -1,0 +1,12 @@
+# Arc Mainnet Deployment Runbook (Preparation Only)
+
+Arc mainnet target: chain ID `5042`, RPC `https://rpc.blockdaemon.mainnet.arc.io`, explorer `https://arc-mainnet.cloud.blockscout.com`, native symbol `USDC`, USDC `0x3600000000000000000000000000000000000000`.
+
+1. Confirm a separately approved deployer and treasury configuration; never place credentials in source.
+2. Run `scripts/preflight-arc-mainnet.js` and confirm `eth_chainId`, USDC bytecode, `symbol() == USDC`, and `decimals() == 6`.
+3. Set `USDC_ADDRESS` explicitly. `scripts/v3/deployV3.js` refuses to deploy MockUSDC on non-local networks.
+4. To include early-adopter preparation, set `DEPLOY_EARLY_ADOPTER_DISCOUNT_REGISTRY=true`, `EARLY_ADOPTER_CAMPAIGN_ID`, and `EARLY_ADOPTER_SNAPSHOT_BLOCK`. `EARLY_ADOPTER_MERKLE_ROOT` is optional before finalization; `EARLY_ADOPTER_DISCOUNT_ACTIVE` and `EARLY_ADOPTER_FREEZE_ROOT` default to false. The script deploys exactly one shared registry, authorizes both controller addresses, and calls `setDiscountRegistry` on both controllers.
+5. The future `arc_mainnet` deployment path configures its newly deployed oracle with p1..p5 = 100/50/25/15/5 USDC and immediately verifies every read. Independently validate it with `scripts/check-mainnet-prices.js` before launch. This preparation task did not execute that path or call `setPrices` on any network.
+6. If no Merkle root is supplied, the deployment flow keeps the campaign inactive and refuses freeze/activation. Before launch, finalize and review the snapshot, set the root, freeze it, and activate the claim window. Contract-level `consume()` enforcement prevents use before freeze even if an admin sets active early.
+
+The Blockscout API endpoint is intentionally configurable and unverified in this phase. No deployment, verification, transaction, signing, or launch action was performed.

--- a/docs/mainnet/EARLY_ADOPTER_SNAPSHOT.md
+++ b/docs/mainnet/EARLY_ADOPTER_SNAPSHOT.md
@@ -1,0 +1,7 @@
+# Early-Adopter Snapshot Preparation
+
+Eligibility is based on one finalized Arc Testnet block (`5042002`): active v3 `.arc` and active v3 `.circle` names only. Legacy/v1/v2 names, expired names, burned/zero-owner names, and documented protocol/admin/internal addresses are excluded. Smart-contract wallets remain eligible unless explicitly excluded. Multiple names produce one wallet entry.
+
+The read-only generator is `scripts/snapshot/generate-arcns-v3-early-adopters.js`. It requires a real finalized block, block hash, both registrar addresses, and a deterministic indexer/RPC export. Every included row must expose registrar provenance through `registrar`, `registrarAddress`, `sourceRegistrar`, or `tldRegistrar`, and that address must exactly match the supplied registrar for its TLD. Explicit legacy/v1/v2 source markers are rejected. When an export has no separate version marker, exact registrar matching is the required v3 source proof; rows without enough provenance fail loudly. Zero owners are excluded. The generator writes the requested manifest/address/CSV/proof placeholders but never fabricates final data or a root. The leaf encoding is `keccak256(abi.encode(campaignId, account))`.
+
+Before launch: finalize the block, verify the export against registrar/controller history, review exclusions and counts, independently recompute the root/proofs, record the manifest git commit and timestamp, set the registry root, freeze it, authorize both controllers, then activate the campaign. The same shared registry enforces one claim across `.arc` and `.circle`.

--- a/docs/mainnet/PRICING.md
+++ b/docs/mainnet/PRICING.md
@@ -1,0 +1,33 @@
+# ArcNS Mainnet Pricing Preparation
+
+## Standard annual pricing
+
+| Label length | Price (USDC/year) | Raw USDC (6 decimals) |
+| --- | ---: | ---: |
+| 5+ | 5 | 5,000,000 |
+| 4 | 15 | 15,000,000 |
+| 3 | 25 | 25,000,000 |
+| 2 | 50 | 50,000,000 |
+| 1 | 100 | 100,000,000 |
+
+The `ArcNSPriceOracle` is the source of truth. Its `setPrices(p1,p2,p3,p4,p5)` order is 1, 2, 3, 4, 5+ characters. The frontend values are display-only; checkout uses `rentPrice` or `discountRentPrice` from the controller.
+
+Arc Testnet keeps its current 50/25/15/10/2 USDC display and oracle configuration.
+
+## Early-adopter first-year/base pricing
+
+Eligible active v3 `.arc` and `.circle` holders receive one wallet-level claim:
+
+| Label length | First-year/base price |
+| --- | ---: |
+| 5+ | 2 USDC |
+| 4 | 10 USDC |
+| 3 | 15 USDC |
+| 2 | 25 USDC |
+| 1 | 50 USDC |
+
+The oracle contains an expired-name premium component: it starts at 100 USDC after expiry and decays linearly to zero over 28 days. `price()` returns separate base and premium values, and the discount route discounts only the base component while preserving the full premium. ArcNS does not market or expose a separate premium package or product in the UI.
+
+Under the current registrar lifecycle, a successful re-registration cannot practically incur a nonzero premium: a name becomes available only after the 90-day grace period, while the oracle premium reaches zero after 28 days. If that lifecycle changes, premium must remain fully charged and must never be discounted. Renewals always use standard oracle pricing.
+
+For durations up to one year, the early price is prorated with upward rounding. For longer durations, the first 365 days use the early price and the remaining duration uses standard oracle pricing.

--- a/docs/mainnet/SECURITY_CHECKLIST.md
+++ b/docs/mainnet/SECURITY_CHECKLIST.md
@@ -1,0 +1,14 @@
+# Mainnet Security Checklist
+
+- [ ] Confirm standard oracle reads are 100/50/25/15/5 USDC in p1..p5 order.
+- [ ] Confirm normal `register()` and `renew()` remain the standard paths.
+- [ ] Confirm discount route requires `owner == msg.sender`, a matured sender-bound commitment, and a valid proof.
+- [ ] Confirm both controllers point to one shared registry, both are authorized, and `consume()` rejects claims until the root is frozen.
+- [ ] Confirm registry consumption and registration are atomic and failed registrations restore `used` state.
+- [ ] Confirm the oracle's expired-name premium is never discounted and renewals never consume a claim.
+- [ ] Confirm the current 90-day availability grace makes the 28-day nonzero premium unreachable for successful re-registration; if lifecycle timing changes, preserve full premium charging.
+- [ ] Confirm pause, resolver allowlist, maxCost, duration, availability, and name validation behavior.
+- [ ] Confirm finalized snapshot block/hash, exclusions, counts, root, and proofs through independent review.
+- [ ] Confirm no production frontend switch occurs before deployed addresses and proofs are available.
+
+No deploy/push/on-chain action was performed in this phase.

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -7,8 +7,14 @@ import DomainCard from "../components/DomainCard";
 import {
   isValidLabel,
   PRICING_TABLE,
+  MAINNET_PRICING,
   type SupportedTLD,
 } from "../lib/normalization";
+import { ACTIVE_CHAIN_ID } from "../lib/chainConfig";
+
+const DISPLAY_PRICING_TABLE = ACTIVE_CHAIN_ID === 5042
+  ? MAINNET_PRICING.map((row) => ({ len: row.label, price: `${row.display.replace("/yr", "")} / year`, annual: row.annualUSDC }))
+  : PRICING_TABLE;
 
 const TRUST_ITEMS = [
   {
@@ -183,7 +189,7 @@ export default function HomePage() {
                 </div>
 
                 <div className="arcns-price-grid">
-                  {PRICING_TABLE.map((row, index) => (
+                  {DISPLAY_PRICING_TABLE.map((row, index) => (
                     <div className="arcns-price-cell" key={row.len} data-best={index === 0 ? "true" : "false"}>
                       <span>{row.len}</span>
                       <strong>{row.price.replace(" / year", "")}</strong>

--- a/frontend/src/lib/chainConfig.ts
+++ b/frontend/src/lib/chainConfig.ts
@@ -57,17 +57,8 @@ export const CHAIN_CONFIGS: Record<number, ChainConfig> = {
     maxCommitmentAge: 86400,
   },
 
-  // ── Arc Mainnet (placeholder — not deployed yet) ───────────────────────────
-  // 5042001: {
-  //   chainId: 5042001,
-  //   name: "Arc Mainnet",
-  //   rpcUrl: "https://rpc.arc.network",
-  //   blockExplorer: "https://arcscan.app",
-  //   contracts: { ... },
-  //   subgraphUrl: "...",
-  //   minCommitmentAge: 60,
-  //   maxCommitmentAge: 86400,
-  // },
+  // Mainnet addresses are intentionally unset until deployment. This target is
+  // configuration/preflight-only and cannot be selected for checkout yet.
 };
 
 /** Get config for the active chain, falling back to Arc Testnet */

--- a/frontend/src/lib/chains.ts
+++ b/frontend/src/lib/chains.ts
@@ -1,6 +1,7 @@
 import { defineChain } from "viem";
 
 export const ARC_TESTNET_CHAIN_ID = 5042002;
+export const ARC_MAINNET_CHAIN_ID = 5042;
 export const ARC_TESTNET_RUNTIME_MODE = "arc-testnet" as const;
 
 export const ARC_TESTNET_RPCS = {
@@ -55,4 +56,17 @@ export const arcTestnet = defineChain({
     },
   },
   testnet: true,
+});
+
+export const arcMainnet = defineChain({
+  id: ARC_MAINNET_CHAIN_ID,
+  name: "Arc",
+  nativeCurrency: { decimals: 6, name: "USD Coin", symbol: "USDC" },
+  rpcUrls: {
+    default: { http: ["https://rpc.blockdaemon.mainnet.arc.io"] },
+    public: { http: ["https://rpc.blockdaemon.mainnet.arc.io"] },
+  },
+  blockExplorers: {
+    default: { name: "Blockscout", url: "https://arc-mainnet.cloud.blockscout.com" },
+  },
 });

--- a/frontend/src/lib/normalization.ts
+++ b/frontend/src/lib/normalization.ts
@@ -57,6 +57,15 @@ export const PRICE_TIERS = [
   { chars: 5, label: "5+ characters", annualUSDC:  2_000_000n, display:  "$2.00/yr"  },
 ] as const;
 
+export const TESTNET_PRICING = PRICE_TIERS;
+export const MAINNET_PRICING = [
+  { chars: 1, label: "1 character", annualUSDC: 100_000_000n, display: "$100.00/yr" },
+  { chars: 2, label: "2 characters", annualUSDC: 50_000_000n, display: "$50.00/yr" },
+  { chars: 3, label: "3 characters", annualUSDC: 25_000_000n, display: "$25.00/yr" },
+  { chars: 4, label: "4 characters", annualUSDC: 15_000_000n, display: "$15.00/yr" },
+  { chars: 5, label: "5+ characters", annualUSDC: 5_000_000n, display: "$5.00/yr" },
+] as const;
+
 export const PRICING_TABLE = [
   { len: "5+ characters", price: "$2.00 / year",  annual:  2_000_000n },
   { len: "4 characters",  price: "$10.00 / year", annual: 10_000_000n },

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -51,6 +51,12 @@ module.exports = {
       accounts: [PRIVATE_KEY],
       gasPrice: "auto",
     },
+    arc_mainnet: {
+      url: process.env.ARC_MAINNET_RPC_URL || "https://rpc.blockdaemon.mainnet.arc.io",
+      chainId: 5042,
+      accounts: [PRIVATE_KEY],
+      gasPrice: "auto",
+    },
   },
   etherscan: {
     apiKey: {
@@ -63,6 +69,15 @@ module.exports = {
         urls: {
           apiURL: "https://testnet.arcscan.app/api",
           browserURL: "https://testnet.arcscan.app",
+        },
+      },
+      {
+        network: "arc_mainnet",
+        chainId: 5042,
+        urls: {
+          // Configure only after validating the provider's API endpoint.
+          apiURL: process.env.ARC_MAINNET_EXPLORER_API_URL || "",
+          browserURL: "https://arc-mainnet.cloud.blockscout.com",
         },
       },
     ],

--- a/scripts/check-mainnet-prices.js
+++ b/scripts/check-mainnet-prices.js
@@ -1,0 +1,29 @@
+"use strict";
+
+const { ethers, network } = require("hardhat");
+
+const EXPECTED = [100_000_000n, 50_000_000n, 25_000_000n, 15_000_000n, 5_000_000n];
+const ORACLE_ABI = [
+  "function price1Char() view returns (uint256)",
+  "function price2Char() view returns (uint256)",
+  "function price3Char() view returns (uint256)",
+  "function price4Char() view returns (uint256)",
+  "function price5Plus() view returns (uint256)",
+];
+
+async function main() {
+  const address = process.env.PRICE_ORACLE_ADDRESS;
+  if (!address) throw new Error("PRICE_ORACLE_ADDRESS is required; read-only validation only.");
+  const oracle = new ethers.Contract(address, ORACLE_ABI, ethers.provider);
+  const actual = await Promise.all([
+    oracle.price1Char(), oracle.price2Char(), oracle.price3Char(), oracle.price4Char(), oracle.price5Plus(),
+  ]);
+  actual.forEach((value, index) => {
+    if (value !== EXPECTED[index]) {
+      throw new Error(`Price mismatch p${index + 1}: expected ${EXPECTED[index]}, received ${value}`);
+    }
+  });
+  console.log(`Price oracle validation passed on ${network.name}: p1/p2/p3/p4/p5 = ${actual.join("/")}`);
+}
+
+main().catch((error) => { console.error(error.message); process.exit(1); });

--- a/scripts/preflight-arc-mainnet.js
+++ b/scripts/preflight-arc-mainnet.js
@@ -1,0 +1,27 @@
+"use strict";
+
+const { ethers, network } = require("hardhat");
+
+const EXPECTED_CHAIN_ID = 5042n;
+const EXPECTED_USDC = "0x3600000000000000000000000000000000000000";
+
+async function main() {
+  const chain = await ethers.provider.getNetwork();
+  if (chain.chainId !== EXPECTED_CHAIN_ID) {
+    throw new Error(`Expected eth_chainId 5042, received ${chain.chainId}`);
+  }
+
+  const code = await ethers.provider.getCode(EXPECTED_USDC);
+  if (code === "0x") throw new Error(`No bytecode at Arc mainnet USDC ${EXPECTED_USDC}`);
+
+  const usdc = new ethers.Contract(EXPECTED_USDC, [
+    "function symbol() view returns (string)",
+    "function decimals() view returns (uint8)",
+  ], ethers.provider);
+  const [symbol, decimals] = await Promise.all([usdc.symbol(), usdc.decimals()]);
+  if (symbol !== "USDC") throw new Error(`Expected USDC symbol, received ${symbol}`);
+  if (decimals !== 6) throw new Error(`Expected USDC decimals 6, received ${decimals}`);
+  console.log(`ARC mainnet preflight passed (${network.name}): chainId=5042 USDC=${EXPECTED_USDC} symbol=${symbol} decimals=${decimals}`);
+}
+
+main().catch((error) => { console.error(error.message); process.exit(1); });

--- a/scripts/snapshot/generate-arcns-v3-early-adopters.js
+++ b/scripts/snapshot/generate-arcns-v3-early-adopters.js
@@ -1,0 +1,159 @@
+"use strict";
+
+/**
+ * Reproducible, read-only snapshot preparation for active v3 .arc/.circle names.
+ *
+ * This script intentionally requires a finalized block and explicit source
+ * contracts. It never fabricates a root, guesses historical ownership, or
+ * submits a transaction. The default output is a manifest-only refusal when
+ * the required indexer/RPC inputs are unavailable.
+ *
+ * A production implementation should supply a deterministic event/indexer
+ * export at --input. The input is a JSON array of records:
+ * { tld, label, owner, expires, registrar, controller, tokenId }
+ */
+
+const fs = require("fs");
+const path = require("path");
+const { ethers } = require("ethers");
+
+const SOURCE_CHAIN_ID = 5042002;
+const CAMPAIGN_ID = process.env.ARCNS_CAMPAIGN_ID || "arcns-v3-early-adopters-1";
+const LEAF_ENCODING = "keccak256(abi.encode(campaignId, account))";
+const DEFAULT_EXCLUSIONS = new Set(
+  (process.env.ARCNS_SNAPSHOT_EXCLUSIONS || "")
+    .split(",")
+    .map((value) => value.trim().toLowerCase())
+    .filter(Boolean),
+);
+
+function arg(name) {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? undefined : process.argv[index + 1];
+}
+
+function fail(message) {
+  throw new Error(`[snapshot-not-ready] ${message}`);
+}
+
+function normalizeAddress(value) {
+  try {
+    return ethers.getAddress(String(value)).toLowerCase();
+  } catch {
+    fail(`invalid address: ${value}`);
+  }
+}
+
+const ZERO_ADDRESS = normalizeAddress(ethers.ZeroAddress);
+const REGISTRAR_FIELDS = ["registrar", "registrarAddress", "sourceRegistrar", "tldRegistrar"];
+const VERSION_FIELDS = ["version", "protocolVersion", "registrarVersion", "sourceVersion", "source"];
+
+function registrarFor(record) {
+  const field = REGISTRAR_FIELDS.find((candidate) => record[candidate] !== undefined && record[candidate] !== null && record[candidate] !== "");
+  if (!field) fail(`record ${record.name || record.label || "<unnamed>"} is missing registrar provenance (${REGISTRAR_FIELDS.join(", ")})`);
+  return normalizeAddress(record[field]);
+}
+
+function assertV3Provenance(record) {
+  for (const field of VERSION_FIELDS) {
+    if (record[field] === undefined || record[field] === null || record[field] === "") continue;
+    const marker = String(record[field]).trim().toLowerCase();
+    if (/(^|[^a-z0-9])(legacy|v?1|v?2)([^a-z0-9]|$)/.test(marker)) {
+      fail(`record ${record.name || record.label || "<unnamed>"} has non-v3 provenance in ${field}: ${record[field]}`);
+    }
+  }
+}
+
+function readInput(inputPath) {
+  if (!inputPath) fail("a real finalized input export is required; no snapshot data was fabricated");
+  if (!fs.existsSync(inputPath)) fail(`input export does not exist: ${inputPath}`);
+  const records = JSON.parse(fs.readFileSync(inputPath, "utf8"));
+  if (!Array.isArray(records)) fail("input export must be a JSON array");
+  return records;
+}
+
+function sortRecords(records, snapshotTimestamp, registrars) {
+  return records
+    .filter((record) => record.tld === "arc" || record.tld === "circle")
+    .map((record) => {
+      // Zero-owner rows are valid export data for burned/empty records and are
+      // excluded by policy; malformed non-zero values still fail loudly.
+      const rawOwner = String(record.owner || "");
+      if (/^0x0{40}$/i.test(rawOwner)) return null;
+      const owner = normalizeAddress(rawOwner);
+      assertV3Provenance(record);
+      const expectedRegistrar = registrars[record.tld];
+      const actualRegistrar = registrarFor(record);
+      if (actualRegistrar !== expectedRegistrar) {
+        fail(`record ${record.name || record.label || "<unnamed>"} registrar ${actualRegistrar} does not match supplied .${record.tld} registrar ${expectedRegistrar}`);
+      }
+      return { ...record, owner, registrar: actualRegistrar };
+    })
+    .filter(Boolean)
+    .filter((record) => record.owner !== ZERO_ADDRESS)
+    .filter((record) => !DEFAULT_EXCLUSIONS.has(record.owner))
+    .filter((record) => Number(record.expires) > snapshotTimestamp && record.active !== false && record.burned !== true)
+    .sort((a, b) => `${a.owner}:${a.tld}:${a.label}`.localeCompare(`${b.owner}:${b.tld}:${b.label}`));
+}
+
+function uniqueWallets(records) {
+  return [...new Set(records.map((record) => record.owner))].sort();
+}
+
+function gitCommit() {
+  try { return require("child_process").execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim(); }
+  catch { return "unknown"; }
+}
+
+function main() {
+  const snapshotBlock = arg("--snapshot-block") || process.env.ARCNS_SNAPSHOT_BLOCK;
+  const snapshotBlockHash = arg("--snapshot-block-hash") || process.env.ARCNS_SNAPSHOT_BLOCK_HASH;
+  const inputPath = arg("--input") || process.env.ARCNS_SNAPSHOT_INPUT;
+  const arcRegistrar = arg("--arc-registrar") || process.env.ARCNS_ARC_REGISTRAR;
+  const circleRegistrar = arg("--circle-registrar") || process.env.ARCNS_CIRCLE_REGISTRAR;
+  const snapshotTimestamp = Number(arg("--snapshot-timestamp") || process.env.ARCNS_SNAPSHOT_TIMESTAMP);
+  if (!snapshotBlock || !snapshotBlockHash) fail("finalized --snapshot-block and --snapshot-block-hash are required");
+  if (!arcRegistrar || !circleRegistrar) fail(".arc and .circle registrar addresses are required");
+  if (!Number.isSafeInteger(snapshotTimestamp) || snapshotTimestamp <= 0) fail("finalized --snapshot-timestamp is required");
+
+  const registrars = {
+    arc: normalizeAddress(arcRegistrar),
+    circle: normalizeAddress(circleRegistrar),
+  };
+  if (registrars.arc === ZERO_ADDRESS || registrars.circle === ZERO_ADDRESS) fail("registrar addresses must be non-zero");
+
+  const records = sortRecords(readInput(inputPath), snapshotTimestamp, registrars);
+  const wallets = uniqueWallets(records);
+  const outDir = path.resolve(arg("--out") || "snapshots/arc-testnet-v3-early-adopters");
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const manifest = {
+    campaignId: CAMPAIGN_ID,
+    sourceChainId: SOURCE_CHAIN_ID,
+    snapshotBlock: Number(snapshotBlock),
+    snapshotBlockHash,
+    snapshotTimestamp,
+    sourceArcRegistrar: registrars.arc,
+    sourceCircleRegistrar: registrars.circle,
+    eligibleWalletCount: wallets.length,
+    eligibleActiveNameCount: records.length,
+    merkleRoot: null,
+    leafEncoding: LEAF_ENCODING,
+    generatorVersion: "1.0.0",
+    gitCommit: gitCommit(),
+    generatedAt: new Date().toISOString(),
+    exclusionPolicy: "active v3 .arc/.circle only; expired/zero-owner/burned/protocol addresses excluded; smart-contract wallets allowed",
+    status: "prepared-input-only; root must be generated and reviewed before launch",
+  };
+  fs.writeFileSync(path.join(outDir, "manifest.json"), JSON.stringify(manifest, null, 2) + "\n");
+  fs.writeFileSync(path.join(outDir, "eligible-addresses.json"), JSON.stringify(wallets, null, 2) + "\n");
+  fs.writeFileSync(path.join(outDir, "eligible-addresses.csv"), "address\n" + wallets.join("\n") + (wallets.length ? "\n" : ""));
+  fs.writeFileSync(path.join(outDir, "merkle-proofs.json"), JSON.stringify({ status: "not-generated", reason: "root/proofs require reviewed finalized input" }, null, 2) + "\n");
+  console.log(`Wrote reviewed-input snapshot preparation to ${outDir}; merkleRoot remains unset.`);
+}
+
+if (require.main === module) {
+  try { main(); } catch (error) { console.error(error.message); process.exit(1); }
+}
+
+module.exports = { normalizeAddress, sortRecords, uniqueWallets };

--- a/scripts/v3/deployV3.js
+++ b/scripts/v3/deployV3.js
@@ -12,7 +12,8 @@
  *   8. ArcNSController (.arc, UUPS proxy)
  *   9. ArcNSController (.circle, UUPS proxy)
  *  10. Wire: TLD nodes, controller auth, resolver roles, reverse node
- *  11. Write deployments/arc_testnet-v3.json
+ *  11. Optionally deploy and wire one shared early-adopter discount registry
+ *  12. Write deployments/arc_testnet-v3.json
  *
  * Usage:
  *   npx hardhat run scripts/v3/deployV3.js --network hardhat
@@ -22,6 +23,12 @@
  *   USDC_ADDRESS      — use existing USDC (skips MockUSDC deploy)
  *   TREASURY_ADDRESS  — treasury EOA (defaults to deployer)
  *   PRIVATE_KEY       — deployer private key (from .env)
+ *   DEPLOY_EARLY_ADOPTER_DISCOUNT_REGISTRY — true to deploy/wire the shared registry
+ *   EARLY_ADOPTER_CAMPAIGN_ID               — required bytes32 or text ID when enabled
+ *   EARLY_ADOPTER_SNAPSHOT_BLOCK            — required finalized source block when enabled
+ *   EARLY_ADOPTER_MERKLE_ROOT               — optional bytes32 before final snapshot
+ *   EARLY_ADOPTER_DISCOUNT_ACTIVE            — defaults false
+ *   EARLY_ADOPTER_FREEZE_ROOT                — defaults false
  */
 
 "use strict";
@@ -45,6 +52,37 @@ function labelhash(label) {
   return ethers.keccak256(ethers.toUtf8Bytes(label));
 }
 
+function envBoolean(value, defaultValue = false) {
+  if (value === undefined || value === "") return defaultValue;
+  if (value === "true") return true;
+  if (value === "false") return false;
+  throw new Error(`Expected boolean true/false, received: ${value}`);
+}
+
+function discountDeploymentConfig(env = process.env) {
+  const enabled = envBoolean(env.DEPLOY_EARLY_ADOPTER_DISCOUNT_REGISTRY, false);
+  if (!enabled) return { enabled: false };
+
+  if (!env.EARLY_ADOPTER_CAMPAIGN_ID) throw new Error("EARLY_ADOPTER_CAMPAIGN_ID is required when discount registry deployment is enabled");
+  const snapshotBlock = Number(env.EARLY_ADOPTER_SNAPSHOT_BLOCK);
+  if (!Number.isSafeInteger(snapshotBlock) || snapshotBlock <= 0) {
+    throw new Error("EARLY_ADOPTER_SNAPSHOT_BLOCK must be a positive safe integer when discount registry deployment is enabled");
+  }
+
+  const campaignId = ethers.isHexString(env.EARLY_ADOPTER_CAMPAIGN_ID, 32)
+    ? env.EARLY_ADOPTER_CAMPAIGN_ID
+    : ethers.id(env.EARLY_ADOPTER_CAMPAIGN_ID);
+  const merkleRoot = env.EARLY_ADOPTER_MERKLE_ROOT || null;
+  if (merkleRoot && !ethers.isHexString(merkleRoot, 32)) throw new Error("EARLY_ADOPTER_MERKLE_ROOT must be bytes32");
+
+  const active = envBoolean(env.EARLY_ADOPTER_DISCOUNT_ACTIVE, false);
+  const freezeRoot = envBoolean(env.EARLY_ADOPTER_FREEZE_ROOT, false);
+  if (!merkleRoot && (active || freezeRoot)) {
+    throw new Error("A finalized EARLY_ADOPTER_MERKLE_ROOT is required before freeze or activation");
+  }
+  return { enabled, campaignId, snapshotBlock, merkleRoot, active, freezeRoot };
+}
+
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
 async function main() {
@@ -59,18 +97,38 @@ async function main() {
   console.log(`Deployer : ${deployer.address}\n`);
 
   const contracts = {};
+  const discountConfig = discountDeploymentConfig();
+
+  if (network.name === "arc_mainnet") {
+    const expected = [100_000_000n, 50_000_000n, 25_000_000n, 15_000_000n, 5_000_000n];
+    const oracleAddress = process.env.PRICE_ORACLE_ADDRESS;
+    if (oracleAddress) {
+      const oracle = new ethers.Contract(oracleAddress, [
+        "function price1Char() view returns (uint256)", "function price2Char() view returns (uint256)",
+        "function price3Char() view returns (uint256)", "function price4Char() view returns (uint256)",
+        "function price5Plus() view returns (uint256)",
+      ], ethers.provider);
+      const actual = await Promise.all([oracle.price1Char(), oracle.price2Char(), oracle.price3Char(), oracle.price4Char(), oracle.price5Plus()]);
+      if (actual.some((value, index) => value !== expected[index])) {
+        throw new Error(`Existing mainnet oracle does not match expected p1/p2/p3/p4/p5 values: ${actual.join("/")}`);
+      }
+      console.log("   ✓ Existing mainnet oracle prices validated; no setPrices transaction will be sent.");
+    }
+  }
 
   // ── 1. USDC ────────────────────────────────────────────────────────────────
   let usdcAddress = process.env.USDC_ADDRESS;
-  if (isLocal || !usdcAddress) {
+  if (isLocal) {
     console.log("📦 Deploying MockUSDC...");
     const MockUSDC = await ethers.getContractFactory("contracts/v3/mocks/MockUSDC.sol:MockUSDC");
     const usdc = await MockUSDC.deploy();
     await usdc.waitForDeployment();
     usdcAddress = await usdc.getAddress();
     console.log(`   MockUSDC: ${usdcAddress}`);
-  } else {
+  } else if (usdcAddress) {
     console.log(`   Using USDC: ${usdcAddress}`);
+  } else {
+    throw new Error(`USDC_ADDRESS is required on non-local network ${network.name}; refusing to deploy MockUSDC.`);
   }
   contracts.usdc = usdcAddress;
 
@@ -103,6 +161,18 @@ async function main() {
   await oracle.waitForDeployment();
   contracts.priceOracle = await oracle.getAddress();
   console.log(`   ArcNSPriceOracle: ${contracts.priceOracle}`);
+  if (network.name === "arc_mainnet") {
+    const expected = [100_000_000n, 50_000_000n, 25_000_000n, 15_000_000n, 5_000_000n];
+    await (await oracle.setPrices(...expected)).wait();
+    const actual = await Promise.all([
+      oracle.price1Char(), oracle.price2Char(), oracle.price3Char(),
+      oracle.price4Char(), oracle.price5Plus(),
+    ]);
+    if (actual.some((value, index) => value !== expected[index])) {
+      throw new Error(`Mainnet oracle post-deploy validation failed: ${actual.join("/")}`);
+    }
+    console.log(`   ✓ Mainnet p1/p2/p3/p4/p5 initialized and verified: ${actual.join("/")}`);
+  }
 
   // ── 5. BaseRegistrar (.arc) ────────────────────────────────────────────────
   const arcNode    = namehash("arc");
@@ -203,7 +273,29 @@ async function main() {
   await (await circleController.setApprovedResolver(contracts.resolver, true)).wait();
   console.log("   ✓ Resolver approved on both controllers");
 
-  // ── 11. Save deployment output ─────────────────────────────────────────────
+  if (discountConfig.enabled) {
+    console.log("\n📦 Deploying one shared ArcNSEarlyAdopterDiscountRegistry...");
+    const DiscountRegistry = await ethers.getContractFactory("contracts/v3/discount/ArcNSEarlyAdopterDiscountRegistry.sol:ArcNSEarlyAdopterDiscountRegistry");
+    const discountRegistry = await DiscountRegistry.deploy(discountConfig.campaignId, discountConfig.snapshotBlock, deployer.address);
+    await discountRegistry.waitForDeployment();
+    contracts.discountRegistry = await discountRegistry.getAddress();
+
+    await (await discountRegistry.setControllerAuthorization(contracts.arcController, true)).wait();
+    await (await discountRegistry.setControllerAuthorization(contracts.circleController, true)).wait();
+    await (await arcController.setDiscountRegistry(contracts.discountRegistry)).wait();
+    await (await circleController.setDiscountRegistry(contracts.discountRegistry)).wait();
+
+    if (discountConfig.merkleRoot) await (await discountRegistry.setMerkleRoot(discountConfig.merkleRoot)).wait();
+    if (discountConfig.freezeRoot) await (await discountRegistry.freezeRoot()).wait();
+    if (discountConfig.active) await (await discountRegistry.setDiscountActive(true)).wait();
+
+    if (await arcController.discountRegistry() !== contracts.discountRegistry || await circleController.discountRegistry() !== contracts.discountRegistry) {
+      throw new Error("Both controllers must point to the same shared discount registry");
+    }
+    console.log("   ✓ Shared discount registry authorized and wired to both controllers");
+  }
+
+  // ── 12. Save deployment output ─────────────────────────────────────────────
   const chainId = Number((await ethers.provider.getNetwork()).chainId);
   const output = {
     network:     network.name,
@@ -218,6 +310,7 @@ async function main() {
       addrReverse: namehash("addr.reverse"),
     },
     upgrades: [],
+    earlyAdopterDiscount: discountConfig,
   };
 
   const outDir = path.join(__dirname, "../../deployments");
@@ -238,4 +331,6 @@ async function main() {
   return output;
 }
 
-main().catch(e => { console.error(e); process.exit(1); });
+if (require.main === module) main().catch(e => { console.error(e); process.exit(1); });
+
+module.exports = { discountDeploymentConfig, envBoolean, main };

--- a/test/v3/DeploymentPreparation.test.js
+++ b/test/v3/DeploymentPreparation.test.js
@@ -1,0 +1,31 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { discountDeploymentConfig } = require("../../scripts/v3/deployV3");
+
+describe("v3 deployment discount preparation", function () {
+  it("is disabled by default and does not require a final root", function () {
+    expect(discountDeploymentConfig({})).to.deep.equal({ enabled: false });
+    const config = discountDeploymentConfig({
+      DEPLOY_EARLY_ADOPTER_DISCOUNT_REGISTRY: "true",
+      EARLY_ADOPTER_CAMPAIGN_ID: "campaign-1",
+      EARLY_ADOPTER_SNAPSHOT_BLOCK: "123",
+    });
+    expect(config).to.include({ enabled: true, snapshotBlock: 123, merkleRoot: null, active: false, freezeRoot: false });
+    expect(config.campaignId).to.equal(ethers.id("campaign-1"));
+  });
+
+  it("requires campaign and snapshot metadata when enabled", function () {
+    expect(() => discountDeploymentConfig({ DEPLOY_EARLY_ADOPTER_DISCOUNT_REGISTRY: "true" })).to.throw("EARLY_ADOPTER_CAMPAIGN_ID");
+    expect(() => discountDeploymentConfig({ DEPLOY_EARLY_ADOPTER_DISCOUNT_REGISTRY: "true", EARLY_ADOPTER_CAMPAIGN_ID: "campaign" })).to.throw("EARLY_ADOPTER_SNAPSHOT_BLOCK");
+  });
+
+  it("refuses freeze or activation without a finalized root", function () {
+    const common = {
+      DEPLOY_EARLY_ADOPTER_DISCOUNT_REGISTRY: "true",
+      EARLY_ADOPTER_CAMPAIGN_ID: "campaign",
+      EARLY_ADOPTER_SNAPSHOT_BLOCK: "123",
+    };
+    expect(() => discountDeploymentConfig({ ...common, EARLY_ADOPTER_DISCOUNT_ACTIVE: "true" })).to.throw("finalized EARLY_ADOPTER_MERKLE_ROOT");
+    expect(() => discountDeploymentConfig({ ...common, EARLY_ADOPTER_FREEZE_ROOT: "true" })).to.throw("finalized EARLY_ADOPTER_MERKLE_ROOT");
+  });
+});

--- a/test/v3/DiscountRegistry.test.js
+++ b/test/v3/DiscountRegistry.test.js
@@ -1,0 +1,35 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("ArcNSEarlyAdopterDiscountRegistry", function () {
+  it("consumes a valid wallet proof once and rejects unauthorized/invalid reuse", async function () {
+    const [owner, controller, alice, bob] = await ethers.getSigners();
+    const campaignId = ethers.id("arcns-v3-early-adopters-1");
+    const Registry = await ethers.getContractFactory("contracts/v3/discount/ArcNSEarlyAdopterDiscountRegistry.sol:ArcNSEarlyAdopterDiscountRegistry");
+    const registry = await Registry.deploy(campaignId, 123, owner.address);
+    await registry.waitForDeployment();
+
+    const leaf = (account) => ethers.keccak256(ethers.AbiCoder.defaultAbiCoder().encode(["bytes32", "address"], [campaignId, account]));
+    const root = leaf(alice.address);
+    await registry.setMerkleRoot(root);
+    await registry.setDiscountActive(true);
+    await registry.setControllerAuthorization(controller.address, true);
+
+    await expect(registry.connect(controller).consume(alice.address, [])).to.be.revertedWithCustomError(registry, "RootNotFrozen");
+    await registry.freezeRoot();
+    await expect(registry.connect(controller).consume(bob.address, [])).to.be.revertedWithCustomError(registry, "InvalidProof");
+    await expect(registry.connect(controller).consume(alice.address, [])).to.emit(registry, "DiscountUsed");
+    expect(await registry.used(alice.address)).to.equal(true);
+    await expect(registry.connect(controller).consume(alice.address, [])).to.be.revertedWithCustomError(registry, "DiscountAlreadyUsed");
+    await expect(registry.connect(bob).consume(alice.address, [])).to.be.revertedWithCustomError(registry, "UnauthorizedController");
+  });
+
+  it("freezes the root and prevents later changes", async function () {
+    const [owner] = await ethers.getSigners();
+    const Registry = await ethers.getContractFactory("contracts/v3/discount/ArcNSEarlyAdopterDiscountRegistry.sol:ArcNSEarlyAdopterDiscountRegistry");
+    const registry = await Registry.deploy(ethers.id("campaign"), 1, owner.address);
+    await registry.setMerkleRoot(ethers.id("root"));
+    await registry.freezeRoot();
+    await expect(registry.setMerkleRoot(ethers.id("other"))).to.be.revertedWithCustomError(registry, "RootAlreadyFrozen");
+  });
+});

--- a/test/v3/Integration.test.js
+++ b/test/v3/Integration.test.js
@@ -137,6 +137,20 @@ async function deployAll() {
   await arcCtrl.setApprovedResolver(await resolver.getAddress(),    true);
   await circleCtrl.setApprovedResolver(await resolver.getAddress(), true);
 
+  // One shared wallet-level early-adopter registry for both controllers.
+  const DiscountF = await ethers.getContractFactory("contracts/v3/discount/ArcNSEarlyAdopterDiscountRegistry.sol:ArcNSEarlyAdopterDiscountRegistry");
+  const campaignId = ethers.id("integration-campaign");
+  const discountRegistry = await DiscountF.deploy(campaignId, 123, deployer.address);
+  await discountRegistry.waitForDeployment();
+  const leaf = ethers.keccak256(ethers.AbiCoder.defaultAbiCoder().encode(["bytes32", "address"], [campaignId, alice.address]));
+  await discountRegistry.setMerkleRoot(leaf);
+  await discountRegistry.freezeRoot();
+  await discountRegistry.setDiscountActive(true);
+  await discountRegistry.setControllerAuthorization(await arcCtrl.getAddress(), true);
+  await discountRegistry.setControllerAuthorization(await circleCtrl.getAddress(), true);
+  await arcCtrl.setDiscountRegistry(await discountRegistry.getAddress());
+  await circleCtrl.setDiscountRegistry(await discountRegistry.getAddress());
+
   // Mint USDC to alice and bob
   await usdc.mint(alice.address, 10_000_000_000n); // 10,000 USDC
   await usdc.mint(bob.address,   10_000_000_000n);
@@ -145,7 +159,7 @@ async function deployAll() {
   await usdc.connect(bob).approve(await arcCtrl.getAddress(),      ethers.MaxUint256);
   await usdc.connect(bob).approve(await circleCtrl.getAddress(),   ethers.MaxUint256);
 
-  return { registry, resolver, oracle, usdc, arcReg, circleReg, reverseReg, arcCtrl, circleCtrl, deployer, alice, bob, treasury };
+  return { registry, resolver, oracle, usdc, arcReg, circleReg, reverseReg, discountRegistry, arcCtrl, circleCtrl, deployer, alice, bob, treasury };
 }
 
 // ─── Test Suite ───────────────────────────────────────────────────────────────
@@ -158,6 +172,12 @@ describe("ArcNS v3 — Integration Tests", function () {
 
   // ── 1. Deployment wiring verification ──────────────────────────────────────
   describe("1. Deployment wiring", function () {
+    it("both controllers use one authorized shared discount registry", async function () {
+      expect(await ctx.arcCtrl.discountRegistry()).to.equal(await ctx.discountRegistry.getAddress());
+      expect(await ctx.circleCtrl.discountRegistry()).to.equal(await ctx.discountRegistry.getAddress());
+      expect(await ctx.discountRegistry.authorizedControllers(await ctx.arcCtrl.getAddress())).to.equal(true);
+      expect(await ctx.discountRegistry.authorizedControllers(await ctx.circleCtrl.getAddress())).to.equal(true);
+    });
     it("arcRegistrar owns the .arc TLD node in registry", async function () {
       expect(await ctx.registry.owner(ARC_NAMEHASH)).to.equal(await ctx.arcReg.getAddress());
     });
@@ -207,6 +227,102 @@ describe("ArcNS v3 — Integration Tests", function () {
 
     it("circleRegistrar is live (owns its baseNode)", async function () {
       expect(await ctx.registry.owner(CIRCLE_NAMEHASH)).to.equal(await ctx.circleReg.getAddress());
+    });
+  });
+
+  describe("11. Shared discount route", function () {
+    it("allows one TLD claim and rejects the same wallet on the other TLD", async function () {
+      const proof = [];
+      const secret = ethers.id("discount-cross-tld");
+      await commitAndWait(ctx.arcCtrl, "discountarc", ctx.alice.address, ONE_YEAR, secret, ethers.ZeroAddress, false, ctx.alice);
+      await ctx.arcCtrl.connect(ctx.alice).registerWithDiscount("discountarc", ctx.alice.address, ONE_YEAR, secret, ethers.ZeroAddress, false, ethers.MaxUint256, proof);
+      expect(await ctx.discountRegistry.used(ctx.alice.address)).to.equal(true);
+
+      const circleSecret = ethers.id("discount-cross-tld-circle");
+      await commitAndWait(ctx.circleCtrl, "discountcircle", ctx.alice.address, ONE_YEAR, circleSecret, ethers.ZeroAddress, false, ctx.alice);
+      await expect(ctx.circleCtrl.connect(ctx.alice).registerWithDiscount("discountcircle", ctx.alice.address, ONE_YEAR, circleSecret, ethers.ZeroAddress, false, ethers.MaxUint256, proof))
+        .to.be.revertedWithCustomError(ctx.discountRegistry, "DiscountAlreadyUsed");
+    });
+
+    it("allows a .circle claim first and then rejects the same wallet on .arc", async function () {
+      const circleSecret = ethers.id("discount-circle-first");
+      await commitAndWait(ctx.circleCtrl, "circlefirst", ctx.alice.address, ONE_YEAR, circleSecret, ethers.ZeroAddress, false, ctx.alice);
+      await ctx.circleCtrl.connect(ctx.alice).registerWithDiscount("circlefirst", ctx.alice.address, ONE_YEAR, circleSecret, ethers.ZeroAddress, false, ethers.MaxUint256, []);
+
+      const arcSecret = ethers.id("discount-arc-second");
+      await commitAndWait(ctx.arcCtrl, "arcsecond", ctx.alice.address, ONE_YEAR, arcSecret, ethers.ZeroAddress, false, ctx.alice);
+      await expect(ctx.arcCtrl.connect(ctx.alice).registerWithDiscount("arcsecond", ctx.alice.address, ONE_YEAR, arcSecret, ethers.ZeroAddress, false, ethers.MaxUint256, []))
+        .to.be.revertedWithCustomError(ctx.discountRegistry, "DiscountAlreadyUsed");
+    });
+
+    it("enforces authorizedControllers through the controller route", async function () {
+      await ctx.discountRegistry.setControllerAuthorization(await ctx.arcCtrl.getAddress(), false);
+      const secret = ethers.id("discount-unauthorized-controller");
+      await commitAndWait(ctx.arcCtrl, "unauthorized", ctx.alice.address, ONE_YEAR, secret, ethers.ZeroAddress, false, ctx.alice);
+      await expect(ctx.arcCtrl.connect(ctx.alice).registerWithDiscount("unauthorized", ctx.alice.address, ONE_YEAR, secret, ethers.ZeroAddress, false, ethers.MaxUint256, []))
+        .to.be.revertedWithCustomError(ctx.discountRegistry, "UnauthorizedController");
+      expect(await ctx.discountRegistry.used(ctx.alice.address)).to.equal(false);
+    });
+
+    it("rolls back used state when registration fails after consume", async function () {
+      const secret = ethers.id("discount-rollback");
+      await register(ctx.arcCtrl, "already-owned", ctx.bob.address, ONE_YEAR, secret, ethers.ZeroAddress, false, ctx.bob);
+      const discountSecret = ethers.id("discount-rollback-claim");
+      await commitAndWait(ctx.arcCtrl, "already-owned", ctx.alice.address, ONE_YEAR, discountSecret, ethers.ZeroAddress, false, ctx.alice);
+      await expect(ctx.arcCtrl.connect(ctx.alice).registerWithDiscount("already-owned", ctx.alice.address, ONE_YEAR, discountSecret, ethers.ZeroAddress, false, ethers.MaxUint256, []))
+        .to.be.reverted;
+      expect(await ctx.discountRegistry.used(ctx.alice.address)).to.equal(false);
+    });
+
+    it("preserves pause and owner/sender protections", async function () {
+      const secret = ethers.id("discount-paused");
+      await commitAndWait(ctx.arcCtrl, "pauseddiscount", ctx.alice.address, ONE_YEAR, secret, ethers.ZeroAddress, false, ctx.alice);
+      await ctx.arcCtrl.pause();
+      await expect(ctx.arcCtrl.connect(ctx.alice).registerWithDiscount("pauseddiscount", ctx.alice.address, ONE_YEAR, secret, ethers.ZeroAddress, false, ethers.MaxUint256, []))
+        .to.be.revertedWithCustomError(ctx.arcCtrl, "EnforcedPause");
+      await ctx.arcCtrl.unpause();
+      await expect(ctx.arcCtrl.connect(ctx.alice).registerWithDiscount("pauseddiscount", ctx.bob.address, ONE_YEAR, secret, ethers.ZeroAddress, false, ethers.MaxUint256, []))
+        .to.be.revertedWithCustomError(ctx.arcCtrl, "DiscountOwnerMustBeSender");
+    });
+
+    it("preserves commitment age and sender binding", async function () {
+      const youngSecret = ethers.id("discount-young");
+      const young = await ctx.arcCtrl.makeCommitment("youngdiscount", ctx.alice.address, ONE_YEAR, youngSecret, ethers.ZeroAddress, false, ctx.alice.address);
+      await ctx.arcCtrl.connect(ctx.alice).commit(young);
+      await expect(ctx.arcCtrl.connect(ctx.alice).registerWithDiscount("youngdiscount", ctx.alice.address, ONE_YEAR, youngSecret, ethers.ZeroAddress, false, ethers.MaxUint256, []))
+        .to.be.revertedWithCustomError(ctx.arcCtrl, "CommitmentTooNew");
+
+      await time.increase(MAX_COMMIT_AGE + 1);
+      await expect(ctx.arcCtrl.connect(ctx.alice).registerWithDiscount("youngdiscount", ctx.alice.address, ONE_YEAR, youngSecret, ethers.ZeroAddress, false, ethers.MaxUint256, []))
+        .to.be.revertedWithCustomError(ctx.arcCtrl, "CommitmentExpired");
+
+      const boundSecret = ethers.id("discount-bound");
+      const bound = await ctx.arcCtrl.makeCommitment("bounddiscount", ctx.alice.address, ONE_YEAR, boundSecret, ethers.ZeroAddress, false, ctx.alice.address);
+      await ctx.arcCtrl.connect(ctx.alice).commit(bound);
+      await time.increase(MIN_COMMIT_AGE + 1);
+      await expect(ctx.arcCtrl.connect(ctx.bob).registerWithDiscount("bounddiscount", ctx.bob.address, ONE_YEAR, boundSecret, ethers.ZeroAddress, false, ethers.MaxUint256, []))
+        .to.be.revertedWithCustomError(ctx.arcCtrl, "CommitmentNotFound");
+    });
+
+    it("preserves resolver approval and maxCost", async function () {
+      const fakeResolver = ctx.bob.address;
+      const resolverSecret = ethers.id("discount-resolver");
+      await commitAndWait(ctx.arcCtrl, "resolverdiscount", ctx.alice.address, ONE_YEAR, resolverSecret, fakeResolver, false, ctx.alice);
+      await expect(ctx.arcCtrl.connect(ctx.alice).registerWithDiscount("resolverdiscount", ctx.alice.address, ONE_YEAR, resolverSecret, fakeResolver, false, ethers.MaxUint256, []))
+        .to.be.revertedWithCustomError(ctx.arcCtrl, "ResolverNotApproved");
+
+      const costSecret = ethers.id("discount-maxcost");
+      await commitAndWait(ctx.arcCtrl, "costdiscount", ctx.alice.address, ONE_YEAR, costSecret, ethers.ZeroAddress, false, ctx.alice);
+      await expect(ctx.arcCtrl.connect(ctx.alice).registerWithDiscount("costdiscount", ctx.alice.address, ONE_YEAR, costSecret, ethers.ZeroAddress, false, 1n, []))
+        .to.be.revertedWithCustomError(ctx.arcCtrl, "PriceExceedsMaxCost");
+      expect(await ctx.discountRegistry.used(ctx.alice.address)).to.equal(false);
+    });
+
+    it("renewal never consumes the discount", async function () {
+      const secret = ethers.id("discount-renewal");
+      await register(ctx.arcCtrl, "renewwithoutclaim", ctx.alice.address, ONE_YEAR, secret, ethers.ZeroAddress, false, ctx.alice);
+      await ctx.arcCtrl.connect(ctx.alice).renew("renewwithoutclaim", ONE_YEAR, ethers.MaxUint256);
+      expect(await ctx.discountRegistry.used(ctx.alice.address)).to.equal(false);
     });
   });
 

--- a/test/v3/PricingPreparation.test.js
+++ b/test/v3/PricingPreparation.test.js
@@ -1,0 +1,17 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("ArcNS pricing preparation", function () {
+  it("preserves testnet defaults and quotes the mainnet target values after setPrices", async function () {
+    const Oracle = await ethers.getContractFactory("contracts/v3/registrar/ArcNSPriceOracle.sol:ArcNSPriceOracle");
+    const oracle = await Oracle.deploy();
+    expect(await oracle.price1Char()).to.equal(50_000_000n);
+    expect(await oracle.price5Plus()).to.equal(2_000_000n);
+    await oracle.setPrices(100_000_000n, 50_000_000n, 25_000_000n, 15_000_000n, 5_000_000n);
+    expect(await oracle.price1Char()).to.equal(100_000_000n);
+    expect(await oracle.price2Char()).to.equal(50_000_000n);
+    expect(await oracle.price3Char()).to.equal(25_000_000n);
+    expect(await oracle.price4Char()).to.equal(15_000_000n);
+    expect(await oracle.price5Plus()).to.equal(5_000_000n);
+  });
+});

--- a/test/v3/SnapshotGenerator.test.js
+++ b/test/v3/SnapshotGenerator.test.js
@@ -1,0 +1,56 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { sortRecords, uniqueWallets } = require("../../scripts/snapshot/generate-arcns-v3-early-adopters");
+
+describe("v3 early-adopter snapshot generator", function () {
+  const registrars = {
+    arc: "0x1000000000000000000000000000000000000001",
+    circle: "0x2000000000000000000000000000000000000002",
+  };
+  const alice = "0x3000000000000000000000000000000000000003";
+  const bob = "0x4000000000000000000000000000000000000004";
+  const timestamp = 1_000;
+
+  function record(overrides = {}) {
+    const tld = overrides.tld || "arc";
+    return {
+      tld,
+      label: overrides.label || "alice",
+      name: `${overrides.label || "alice"}.${tld}`,
+      owner: overrides.owner || alice,
+      expires: overrides.expires ?? 2_000,
+      registrar: overrides.registrar || registrars[tld],
+      version: overrides.version || "v3",
+      active: overrides.active ?? true,
+      burned: overrides.burned ?? false,
+      ...overrides,
+    };
+  }
+
+  it("includes valid .arc and .circle rows and deduplicates a wallet across TLDs", function () {
+    const rows = sortRecords([record(), record({ tld: "circle", registrar: registrars.circle })], timestamp, registrars);
+    expect(rows).to.have.length(2);
+    expect(uniqueWallets(rows)).to.deep.equal([alice.toLowerCase()]);
+  });
+
+  it("hard-fails wrong registrar membership for either TLD", function () {
+    expect(() => sortRecords([record({ registrar: registrars.circle })], timestamp, registrars)).to.throw("does not match supplied .arc registrar");
+    expect(() => sortRecords([record({ tld: "circle", registrar: registrars.arc })], timestamp, registrars)).to.throw("does not match supplied .circle registrar");
+  });
+
+  it("hard-fails missing registrar provenance and explicit legacy versions", function () {
+    const missing = record();
+    delete missing.registrar;
+    expect(() => sortRecords([missing], timestamp, registrars)).to.throw("missing registrar provenance");
+    expect(() => sortRecords([record({ version: "v2" })], timestamp, registrars)).to.throw("non-v3 provenance");
+  });
+
+  it("excludes zero owners, expired rows, and burned rows", function () {
+    const rows = sortRecords([
+      record({ owner: ethers.ZeroAddress }),
+      record({ owner: bob, label: "expired", name: "expired.arc", expires: timestamp }),
+      record({ owner: bob, label: "burned", name: "burned.arc", burned: true }),
+    ], timestamp, registrars);
+    expect(rows).to.deep.equal([]);
+  });
+});


### PR DESCRIPTION
This PR prepares ArcNS for Arc mainnet pricing and one-time early-adopter discount support.

Included:
- Adds final Arc mainnet pricing preparation: 100 / 50 / 25 / 15 / 5 USDC per year by character tier.
- Preserves existing Arc Testnet/default pricing behavior.
- Adds a shared Early Adopter Discount Registry for one-time wallet-level eligibility across .arc and .circle.
- Adds registerWithDiscount while preserving the normal register and renew flows.
- Enforces owner == msg.sender for discounted registrations.
- Requires Merkle root freezing before discount consumption.
- Prepares a deterministic fresh snapshot generator for active v3 .arc and .circle holders.
- Adds Arc mainnet preflight checks and deployment preparation.
- Adds mainnet pricing, snapshot, deployment, and security documentation.
- Adds tests for discount registry, pricing preparation, snapshot generator, deployment preparation, and cross-TLD integration.

Not included:
- No mainnet deployment.
- No on-chain transaction.
- No Merkle root finalization.
- No final snapshot data.
- No production switch to mainnet.
- No token/tokenomics/DAO/governance work.
- No env, private key, secret, or real deployment artifact changes.

Validation:
- Hardhat compile passed.
- Full v3 test suite passed.
- Frontend lint passed with existing warnings only.
- Frontend build passed.
- git diff --check passed.