### PR TITLE
chore: fix Arc mainnet preflight script

### DIFF
--- a/docs/mainnet/DEPLOYMENT_RUNBOOK.md
+++ b/docs/mainnet/DEPLOYMENT_RUNBOOK.md
@@ -3,7 +3,7 @@
 Arc mainnet target: chain ID `5042`, RPC `https://rpc.blockdaemon.mainnet.arc.io`, explorer `https://arc-mainnet.cloud.blockscout.com`, native symbol `USDC`, USDC `0x3600000000000000000000000000000000000000`.
 
 1. Confirm a separately approved deployer and treasury configuration; never place credentials in source.
-2. Run `scripts/preflight-arc-mainnet.js` and confirm `eth_chainId`, USDC bytecode, `symbol() == USDC`, and `decimals() == 6`.
+2. Run `npx hardhat run scripts/preflight-arc-mainnet.js --network arc_mainnet` and confirm `eth_chainId`, USDC bytecode, `symbol() == USDC`, and `decimals() == 6`.
 3. Set `USDC_ADDRESS` explicitly. `scripts/v3/deployV3.js` refuses to deploy MockUSDC on non-local networks.
 4. To include early-adopter preparation, set `DEPLOY_EARLY_ADOPTER_DISCOUNT_REGISTRY=true`, `EARLY_ADOPTER_CAMPAIGN_ID`, and `EARLY_ADOPTER_SNAPSHOT_BLOCK`. `EARLY_ADOPTER_MERKLE_ROOT` is optional before finalization; `EARLY_ADOPTER_DISCOUNT_ACTIVE` and `EARLY_ADOPTER_FREEZE_ROOT` default to false. The script deploys exactly one shared registry, authorizes both controller addresses, and calls `setDiscountRegistry` on both controllers.
 5. The future `arc_mainnet` deployment path configures its newly deployed oracle with p1..p5 = 100/50/25/15/5 USDC and immediately verifies every read. Independently validate it with `scripts/check-mainnet-prices.js` before launch. This preparation task did not execute that path or call `setPrices` on any network.

--- a/scripts/preflight-arc-mainnet.js
+++ b/scripts/preflight-arc-mainnet.js
@@ -2,26 +2,41 @@
 
 const { ethers, network } = require("hardhat");
 
-const EXPECTED_CHAIN_ID = 5042n;
+const EXPECTED_CHAIN_ID = 5042;
 const EXPECTED_USDC = "0x3600000000000000000000000000000000000000";
 
 async function main() {
-  const chain = await ethers.provider.getNetwork();
-  if (chain.chainId !== EXPECTED_CHAIN_ID) {
-    throw new Error(`Expected eth_chainId 5042, received ${chain.chainId}`);
+  const networkInfo = await ethers.provider.getNetwork();
+  const chainId = Number(networkInfo.chainId);
+  if (chainId !== EXPECTED_CHAIN_ID) {
+    throw new Error(`Expected eth_chainId ${EXPECTED_CHAIN_ID}, received ${networkInfo.chainId}`);
   }
 
-  const code = await ethers.provider.getCode(EXPECTED_USDC);
+  const [latestBlock, codeRaw] = await Promise.all([
+    ethers.provider.getBlockNumber(),
+    ethers.provider.getCode(EXPECTED_USDC),
+  ]);
+  const code = String(codeRaw);
   if (code === "0x") throw new Error(`No bytecode at Arc mainnet USDC ${EXPECTED_USDC}`);
 
   const usdc = new ethers.Contract(EXPECTED_USDC, [
     "function symbol() view returns (string)",
     "function decimals() view returns (uint8)",
   ], ethers.provider);
-  const [symbol, decimals] = await Promise.all([usdc.symbol(), usdc.decimals()]);
+  const [symbolRaw, decimalsRaw] = await Promise.all([usdc.symbol(), usdc.decimals()]);
+  const symbol = String(symbolRaw);
+  const decimals = Number(decimalsRaw);
   if (symbol !== "USDC") throw new Error(`Expected USDC symbol, received ${symbol}`);
   if (decimals !== 6) throw new Error(`Expected USDC decimals 6, received ${decimals}`);
-  console.log(`ARC mainnet preflight passed (${network.name}): chainId=5042 USDC=${EXPECTED_USDC} symbol=${symbol} decimals=${decimals}`);
+
+  console.log("Arc mainnet preflight passed");
+  console.log(`Network: ${network.name}`);
+  console.log(`Chain ID: ${chainId}`);
+  console.log(`Latest block: ${latestBlock}`);
+  console.log(`USDC address: ${EXPECTED_USDC}`);
+  console.log("USDC bytecode present: yes");
+  console.log(`USDC symbol: ${symbol}`);
+  console.log(`USDC decimals: ${decimals}`);
 }
 
 main().catch((error) => { console.error(error.message); process.exit(1); });


### PR DESCRIPTION
This PR fixes the Arc mainnet read-only preflight script and updates the deployment runbook with the correct Hardhat network invocation.

Included:
- Fixes ethers v6 bigint/number comparison issue for USDC decimals.
- Normalizes chain ID, USDC symbol, decimals, and bytecode checks.
- Adds clearer successful preflight output.
- Fetches and prints latest block during preflight.
- Updates runbook command from direct node execution to:
  npx hardhat run scripts/preflight-arc-mainnet.js --network arc_mainnet

Validated read-only against:
- RPC used for testing only: https://radar-api-rpc.up.railway.app
- Chain ID: 5042
- USDC address: 0x3600000000000000000000000000000000000000
- USDC symbol: USDC
- USDC decimals: 6

Not included:
- No deployment.
- No on-chain write.
- No signing.
- No price update.
- No Merkle root set/freeze/activation.
- No ownership or role transfer.
- No frontend production switch.
- No deployment artifact change.
- No token/tokenomics/DAO/governance work.
- No env, private key, or secret changes.

Validation:
- git diff --check passed.
- Read-only Arc mainnet preflight passed.
- Exit code: 0.