### PR TITLE
docs: add ArcNS mainnet admin ownership plan

### DIFF
--- a/docs/mainnet/ADMIN_OWNERSHIP_PLAN.md
+++ b/docs/mainnet/ADMIN_OWNERSHIP_PLAN.md
@@ -1,0 +1,130 @@
+# ArcNS Mainnet Admin and Ownership Plan (Aşama 4B)
+
+Status: finalized administration and ownership plan for launch preparation only. This document records intended mainnet authority boundaries; it does not execute them.
+
+## Executive summary
+
+- ArcNS mainnet will use a 2-of-3 Admin Safe, following the same structural pattern as the testnet admin Safe. The final mainnet Safe address, owners, and threshold record are still launch blockers and must not be inferred from testnet values.
+- The deployer wallet will be the treasury recipient at launch as a deliberate operational simplification.
+- A standard 48-hour `TimelockController` is planned to hold controller and resolver upgrade authority. Its minimum delay will be `172800` seconds.
+- Emergency pause authority will be held by the Admin Safe.
+- The deployer EOA is for deployment and bootstrap only. After handoff, it must not retain admin, ownership, upgrade, root, freeze, activation, pause, oracle, resolver, registrar, registry, or discount-registry authority.
+
+The treasury recipient is not the protocol admin. Receiving protocol revenue does not, by itself, grant authority over contracts or roles.
+
+## Final role ownership table
+
+`TBD` means the final mainnet address must be recorded and independently verified before deployment or handoff. No address is invented by this plan.
+
+| Component / Role | Launch owner/admin | Later owner/admin if different | Reason | Launch blocker? |
+| ---------------- | ------------------ | ------------------------------ | ------ | --------------- |
+| Registry root owner | Admin Safe (address TBD) | Same | Root ownership is critical protocol authority and must be multisig-controlled. | Yes — Safe address and handoff pending |
+| `.arc` registrar owner | Admin Safe (address TBD) | Same | Registrar administration must not remain with the deployer. | Yes — Safe address and handoff pending |
+| `.circle` registrar owner | Admin Safe (address TBD) | Same | Registrar administration must not remain with the deployer. | Yes — Safe address and handoff pending |
+| `.arc` controller admin | Admin Safe (address TBD) | Same | Operational administration requires multisig approval. | Yes — Safe address and role handoff pending |
+| `.circle` controller admin | Admin Safe (address TBD) | Same | Operational administration requires multisig approval. | Yes — Safe address and role handoff pending |
+| `.arc` controller upgrader | 48-hour Timelock (address TBD) | Same | Upgrade operations require a visible 48-hour delay. | Yes — Timelock deployment and role handoff pending |
+| `.circle` controller upgrader | 48-hour Timelock (address TBD) | Same | Upgrade operations require a visible 48-hour delay. | Yes — Timelock deployment and role handoff pending |
+| `.arc` controller pauser | Admin Safe (address TBD) | Same | Emergency response must be prompt but protected by multisig approval. | Yes — Safe address and role handoff pending |
+| `.circle` controller pauser | Admin Safe (address TBD) | Same | Emergency response must be prompt but protected by multisig approval. | Yes — Safe address and role handoff pending |
+| Resolver admin | Admin Safe (address TBD) | Same | Resolver administration must be multisig-controlled. | Yes — Safe address and role handoff pending |
+| Resolver upgrader | 48-hour Timelock (address TBD) | Same | Resolver upgrades require a visible 48-hour delay. | Yes — Timelock deployment and role handoff pending |
+| Reverse registrar owner | Admin Safe (address TBD) | Same | Reverse registrar ownership must not remain with the deployer. | Yes — Safe address and handoff pending |
+| PriceOracle owner | Admin Safe (address TBD) | 48-hour Timelock recommended after launch stabilization | Safe ownership simplifies launch coordination; later timelock custody reduces rapid-change risk. | Yes — Safe address and handoff pending |
+| DiscountRegistry owner | Admin Safe (address TBD) | Timelock migration may be considered only after launch is stable | Launch coordination includes controller authorization, root, freeze, and activation administration. | Yes — Safe address and handoff pending |
+| DiscountRegistry authorized `.arc` controller | Final deployed `.arc` controller address (TBD), authorized by DiscountRegistry owner | Same unless a reviewed controller migration occurs | Only the finalized controller may consume `.arc` campaign claims. | Yes — deployed controller address and authorization pending |
+| DiscountRegistry authorized `.circle` controller | Final deployed `.circle` controller address (TBD), authorized by DiscountRegistry owner | Same unless a reviewed controller migration occurs | Only the finalized controller may consume `.circle` campaign claims. | Yes — deployed controller address and authorization pending |
+| Treasury recipient | Deployer wallet (address TBD) | Treasury Safe recommended in a future reviewed migration | Operational simplicity at launch; this is revenue custody, not protocol administration. | Yes — final deployer/treasury address pending |
+| Deployer EOA | Deployment/bootstrap only; treasury recipient at launch | Treasury recipient only, if retained as the final launch choice | The deployer must have no lasting privileged protocol authority after handoff. | Yes — address and complete revoke verification pending |
+| Timelock proposer | Admin Safe (address TBD) | Same unless the authority model is deliberately revised | The Safe schedules reviewed critical operations. | Yes — Safe and Timelock deployment/configuration pending |
+| Timelock canceller | Admin Safe (address TBD) | Same unless the authority model is deliberately revised | The Safe can cancel unsafe or obsolete queued operations. | Yes — Safe and Timelock deployment/configuration pending |
+| Timelock executor | Admin Safe (address TBD) | May be changed later through a separately reviewed authority-model decision | A restricted executor is simpler for launch operations. | Yes — Safe and Timelock deployment/configuration pending |
+
+## Treasury risk note
+
+Using the deployer wallet as treasury recipient is acceptable for launch only as a deliberate operational choice. It creates single-EOA custody risk: loss, compromise, or misuse of that key could affect received treasury funds.
+
+Treasury receipt does not grant protocol admin control by itself. All admin, ownership, upgrade, pause, root, freeze, activation, oracle, resolver, registrar, registry, and discount-registry rights must be moved away from the deployer during handoff. The deployer must not retain any such authority merely because it remains the treasury recipient.
+
+A future reviewed migration from the deployer wallet to a dedicated Treasury Safe remains recommended.
+
+## Timelock explanation
+
+The timelock is a smart contract, not a separate wallet. It does not have a private key and nobody signs transactions "as" the timelock. It enforces a delay before assigned critical operations can be executed.
+
+The planned minimum delay is 48 hours: `minDelay = 172800` seconds. The Admin Safe will schedule operations as proposer, cancel operations as canceller, and execute ready operations as executor for launch simplicity. The timelock contract then performs the authorized action after the delay according to its assigned on-chain role.
+
+## Timelock scope
+
+At launch:
+
+- The Timelock controls the upgrader role for the `.arc` controller.
+- The Timelock controls the upgrader role for the `.circle` controller.
+- The Timelock controls the resolver upgrader role.
+- PriceOracle ownership starts at the Admin Safe for launch simplicity. Migration to the Timelock is recommended after launch stabilization and a separate review.
+- DiscountRegistry ownership starts at the Admin Safe for coordinated launch administration. Migration to the Timelock may be considered only after launch is stable and through a separately reviewed plan.
+
+Emergency pause remains outside the timelock and is held by the Admin Safe so that a 48-hour delay does not prevent incident response.
+
+## Post-deployment handoff and revoke checklist
+
+These are future launch actions, not actions performed by this documentation phase.
+
+- [ ] Transfer registry root ownership to the Admin Safe.
+- [ ] Transfer `.arc` registrar ownership to the Admin Safe.
+- [ ] Transfer `.circle` registrar ownership to the Admin Safe.
+- [ ] Grant controller admin roles to the Admin Safe.
+- [ ] Grant controller pause roles to the Admin Safe.
+- [ ] Grant controller upgrade roles to the Timelock.
+- [ ] Grant resolver admin to the Admin Safe.
+- [ ] Grant resolver upgrade role to the Timelock.
+- [ ] Transfer reverse registrar ownership to the Admin Safe.
+- [ ] Transfer PriceOracle ownership to the Admin Safe.
+- [ ] Transfer DiscountRegistry ownership to the Admin Safe.
+- [ ] Authorize only the finalized `.arc` and `.circle` controller addresses in the DiscountRegistry.
+- [ ] Set both controllers' discount registry address to the finalized shared DiscountRegistry.
+- [ ] Set the treasury recipient to the finalized deployer wallet.
+- [ ] Verify the deployer has no admin, owner, pause, upgrade, oracle, resolver, registrar, registry, or discount-registry authority after handoff.
+- [ ] Verify the deployer remains only the treasury recipient, if that is the final launch choice.
+
+Every transfer, grant, revoke, authorization, address assignment, and final role read must be independently reviewed against the finalized deployed addresses before mainnet activation.
+
+## Launch blockers
+
+- [ ] Final mainnet Admin Safe address is not yet recorded.
+- [ ] Final Safe owner addresses and the 2-of-3 threshold are not yet recorded.
+- [ ] Final deployer/treasury address is not yet recorded in launch documentation.
+- [ ] Timelock is not deployed.
+- [ ] Timelock address is not known.
+- [ ] Role handoff and deployer revocation are not executed or verified.
+- [ ] Blockscout API verification path is unresolved.
+- [ ] Mainnet indexer/subgraph plan is unresolved.
+- [ ] Focused security review is not completed.
+- [ ] Frontend mainnet cutover plan is not prepared.
+- [ ] Deploy-grade RPC is not finalized. The previously confirmed `https://radar-api-rpc.up.railway.app` endpoint is a read-only/testing fallback only and must not be treated as deployment-grade infrastructure.
+
+Arc mainnet is not ready to deploy while any launch blocker above remains open.
+
+## Non-goals and safety boundary
+
+- This document does not deploy contracts.
+- This document does not create the Safe.
+- This document does not deploy the TimelockController.
+- This document does not submit transactions or call write functions.
+- This document does not sign anything.
+- This document does not transfer ownership or roles.
+- This document does not grant or revoke roles.
+- This document does not set prices, set or freeze a Merkle root, or activate a discount campaign.
+- This document does not activate mainnet.
+- This document does not switch the frontend to mainnet.
+- This document does not modify environment values, secrets, wallet credentials, private keys, or deployment artifacts.
+- This document does not cover unrelated private planning materials.
+
+## Related finalized preparation inputs
+
+- Mainnet pricing: [`PRICING.md`](./PRICING.md)
+- Early-adopter snapshot: [`EARLY_ADOPTER_SNAPSHOT.md`](./EARLY_ADOPTER_SNAPSHOT.md)
+- Deployment preparation runbook: [`DEPLOYMENT_RUNBOOK.md`](./DEPLOYMENT_RUNBOOK.md)
+- Security checklist: [`SECURITY_CHECKLIST.md`](./SECURITY_CHECKLIST.md)
+
+The confirmed Arc mainnet chain ID is `5042`. The confirmed USDC address is `0x3600000000000000000000000000000000000000`, with symbol `USDC` and 6 decimals. These read-only preflight facts do not remove any launch blocker listed above.

--- a/docs/mainnet/DEPLOYMENT_RUNBOOK.md
+++ b/docs/mainnet/DEPLOYMENT_RUNBOOK.md
@@ -1,6 +1,8 @@
 # Arc Mainnet Deployment Runbook (Preparation Only)
 
-Arc mainnet target: chain ID `5042`, RPC `https://rpc.blockdaemon.mainnet.arc.io`, explorer `https://arc-mainnet.cloud.blockscout.com`, native symbol `USDC`, USDC `0x3600000000000000000000000000000000000000`.
+The finalized launch authority model and unresolved administration blockers are recorded in [`ADMIN_OWNERSHIP_PLAN.md`](./ADMIN_OWNERSHIP_PLAN.md).
+
+Arc mainnet target: chain ID `5042`, deploy-grade RPC still to be finalized (the previously listed `https://rpc.blockdaemon.mainnet.arc.io` endpoint remains a candidate pending approval), explorer `https://arc-mainnet.cloud.blockscout.com`, native symbol `USDC`, USDC `0x3600000000000000000000000000000000000000`. The confirmed `https://radar-api-rpc.up.railway.app` endpoint is a read-only/testing fallback only and is not deployment-grade RPC.
 
 1. Confirm a separately approved deployer and treasury configuration; never place credentials in source.
 2. Run `npx hardhat run scripts/preflight-arc-mainnet.js --network arc_mainnet` and confirm `eth_chainId`, USDC bytecode, `symbol() == USDC`, and `decimals() == 6`.

--- a/docs/mainnet/SECURITY_CHECKLIST.md
+++ b/docs/mainnet/SECURITY_CHECKLIST.md
@@ -1,5 +1,6 @@
 # Mainnet Security Checklist
 
+- [ ] Confirm every ownership, admin, upgrade, pause, treasury, and deployer-revocation item in [`ADMIN_OWNERSHIP_PLAN.md`](./ADMIN_OWNERSHIP_PLAN.md).
 - [ ] Confirm standard oracle reads are 100/50/25/15/5 USDC in p1..p5 order.
 - [ ] Confirm normal `register()` and `renew()` remain the standard paths.
 - [ ] Confirm discount route requires `owner == msg.sender`, a matured sender-bound commitment, and a valid proof.


### PR DESCRIPTION
This PR documents the ArcNS mainnet administration and ownership plan for Aşama 4B.

Included:
- Adds docs/mainnet/ADMIN_OWNERSHIP_PLAN.md.
- Documents the 2-of-3 Admin Safe model.
- Documents deployer wallet as launch treasury recipient, including single-EOA custody risk.
- Clarifies that treasury recipient does not equal protocol admin.
- Documents the planned 48-hour TimelockController model.
- Assigns emergency pause authority to the Admin Safe.
- Defines launch ownership recommendations for registry, registrars, controllers, resolver, reverse registrar, PriceOracle, DiscountRegistry, treasury, deployer, and timelock roles.
- Adds post-deployment handoff / deployer revocation checklist.
- Adds unresolved launch blockers.
- Cross-links the plan from the deployment runbook and security checklist.

Not included:
- No deployment.
- No on-chain write.
- No signing.
- No Safe creation.
- No Timelock deployment.
- No ownership or role transfer.
- No price update.
- No Merkle root set/freeze/activation.
- No frontend mainnet switch.
- No deployment artifact change.
- No env, private key, or secret changes.

Validation:
- Documentation-only diff.
- git diff --check passed.
- Restricted-reference scan passed.