### PR TITLE
fix: harden mainnet launch tooling guards

### DIFF
--- a/docs/mainnet/ADMIN_OWNERSHIP_PLAN.md
+++ b/docs/mainnet/ADMIN_OWNERSHIP_PLAN.md
@@ -89,6 +89,8 @@ These are future launch actions, not actions performed by this documentation pha
 
 Every transfer, grant, revoke, authorization, address assignment, and final role read must be independently reviewed against the finalized deployed addresses before mainnet activation.
 
+The strictly read-only `scripts/mainnet/assert-admin-handoff.js` must verify the finalized Safe, Timelock, treasury, deployed addresses, owners, roles, and deployer revocation before public launch. It does not execute the handoff and must not be treated as proof until run against the final deployment with independently reviewed expected values.
+
 ## Launch blockers
 
 - [ ] Final mainnet Admin Safe address is not yet recorded.

--- a/docs/mainnet/DEPLOYMENT_RUNBOOK.md
+++ b/docs/mainnet/DEPLOYMENT_RUNBOOK.md
@@ -1,5 +1,7 @@
 # Arc Mainnet Deployment Runbook (Preparation Only)
 
+> Tooling guard update: `snapshots/arc-testnet-v3-early-adopters/manifest.json` is the canonical campaign source. Mainnet tooling fails closed on missing, malformed, or contradictory facts. `deployV3.js` may deploy and wire the registry but never sets the root, freezes it, or activates the campaign. Those are three separate reviewed operations, and activation is blocked until verification, read-only authority handoff assertion, indexer readiness, proof delivery, and frontend cutover readiness are complete.
+
 The finalized launch authority model and unresolved administration blockers are recorded in [`ADMIN_OWNERSHIP_PLAN.md`](./ADMIN_OWNERSHIP_PLAN.md).
 
 Arc mainnet target: chain ID `5042`, deploy-grade RPC still to be finalized (the previously listed `https://rpc.blockdaemon.mainnet.arc.io` endpoint remains a candidate pending approval), explorer `https://arc-mainnet.cloud.blockscout.com`, native symbol `USDC`, USDC `0x3600000000000000000000000000000000000000`. The confirmed `https://radar-api-rpc.up.railway.app` endpoint is a read-only/testing fallback only and is not deployment-grade RPC.
@@ -7,8 +9,8 @@ Arc mainnet target: chain ID `5042`, deploy-grade RPC still to be finalized (the
 1. Confirm a separately approved deployer and treasury configuration; never place credentials in source.
 2. Run `npx hardhat run scripts/preflight-arc-mainnet.js --network arc_mainnet` and confirm `eth_chainId`, USDC bytecode, `symbol() == USDC`, and `decimals() == 6`.
 3. Set `USDC_ADDRESS` explicitly. `scripts/v3/deployV3.js` refuses to deploy MockUSDC on non-local networks.
-4. To include early-adopter preparation, set `DEPLOY_EARLY_ADOPTER_DISCOUNT_REGISTRY=true`, `EARLY_ADOPTER_CAMPAIGN_ID`, and `EARLY_ADOPTER_SNAPSHOT_BLOCK`. `EARLY_ADOPTER_MERKLE_ROOT` is optional before finalization; `EARLY_ADOPTER_DISCOUNT_ACTIVE` and `EARLY_ADOPTER_FREEZE_ROOT` default to false. The script deploys exactly one shared registry, authorizes both controller addresses, and calls `setDiscountRegistry` on both controllers.
+4. To include early-adopter preparation, set only `DEPLOY_EARLY_ADOPTER_DISCOUNT_REGISTRY=true`. The script validates the version-controlled finalized manifest before any write, deploys exactly one shared registry from its campaign ID and snapshot block, authorizes both controllers, and leaves the root unset, unfrozen, and inactive. Any supplied campaign fact must exactly match the manifest.
 5. The future `arc_mainnet` deployment path configures its newly deployed oracle with p1..p5 = 100/50/25/15/5 USDC and immediately verifies every read. Independently validate it with `scripts/check-mainnet-prices.js` before launch. This preparation task did not execute that path or call `setPrices` on any network.
-6. If no Merkle root is supplied, the deployment flow keeps the campaign inactive and refuses freeze/activation. Before launch, finalize and review the snapshot, set the root, freeze it, and activate the claim window. Contract-level `consume()` enforcement prevents use before freeze even if an admin sets active early.
+6. After deployment and independent verification, use the single-purpose guarded set-root and freeze-root operations in separate reviews. Run the read-only authority assertion after handoff. Activation is a later separate operation and remains forbidden until verification, handoff, indexer, proof-delivery, and frontend readiness gates pass. A wrong frozen root is irreversible in that registry and requires replacement/migration plus controller reconfiguration.
 
 The Blockscout API endpoint is intentionally configurable and unverified in this phase. No deployment, verification, transaction, signing, or launch action was performed.

--- a/docs/mainnet/FOCUSED_SECURITY_REVIEW.md
+++ b/docs/mainnet/FOCUSED_SECURITY_REVIEW.md
@@ -2,6 +2,8 @@
 
 Status: internal focused review completed on branch `security/focused-mainnet-launch-review`.
 
+Remediation status: FSR-02 and FSR-06 are addressed by the Aşama 5A tooling guards. FSR-01 is partially addressed by a fail-closed read-only handoff assertion; final Safe/Timelock creation, handoff execution, and verification remain launch actions and blockers.
+
 This is an **internal focused review**, **not an external audit**. Mainnet deployment remains blocked until the blockers listed below are resolved and independently rechecked. No deployment, Arc on-chain write, signing, ownership transfer, role change, price update, Merkle-root update, campaign activation, production frontend switch, staging, commit, or push was performed by this review.
 
 ## Executive verdict
@@ -12,7 +14,7 @@ This is an **internal focused review**, **not an external audit**. Mainnet deplo
 
 The core discount and pricing design is internally coherent: the campaign and snapshot block are immutable; a frozen root cannot be changed; `consume` is restricted to authorized controllers; usage is keyed by wallet in one shared registry; controller discount registration binds the eligible account to `msg.sender`; the claim is atomic with registration; renewals do not consume or apply the discount; and expired-name premium remains payable in full.
 
-Deployment is nevertheless blocked by incomplete launch governance and infrastructure, and by insufficient fail-closed pinning in the write-capable deployment path.
+Deployment remains blocked by incomplete launch administration and infrastructure. Aşama 5A added fail-closed snapshot pinning and separated discount lifecycle operations; these guards still require independent review before launch.
 
 ## Findings summary
 

--- a/docs/mainnet/SECURITY_CHECKLIST.md
+++ b/docs/mainnet/SECURITY_CHECKLIST.md
@@ -10,6 +10,11 @@
 - [ ] Confirm the current 90-day availability grace makes the 28-day nonzero premium unreachable for successful re-registration; if lifecycle timing changes, preserve full premium charging.
 - [ ] Confirm pause, resolver allowlist, maxCost, duration, availability, and name validation behavior.
 - [ ] Confirm finalized snapshot block/hash, exclusions, counts, root, and proofs through independent review.
+- [ ] Confirm deployment loaded the canonical finalized manifest and failed closed on every contradictory campaign value.
+- [ ] Confirm deployment left the discount root unset, unfrozen, and inactive; set, freeze, and activation are separate reviewed operations.
+- [ ] Run the read-only `scripts/mainnet/assert-admin-handoff.js` and require its PASS result before public launch.
 - [ ] Confirm no production frontend switch occurs before deployed addresses and proofs are available.
+
+Deploy-grade RPC selection, Blockscout verification, mainnet indexer/subgraph deployment, and frontend cutover remain unresolved launch blockers. This checklist is not mainnet deployment approval.
 
 No deploy/push/on-chain action was performed in this phase.

--- a/scripts/mainnet/assert-admin-handoff.js
+++ b/scripts/mainnet/assert-admin-handoff.js
@@ -1,0 +1,48 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { ethers } = require("hardhat");
+const { ARC_MAINNET_CHAIN_ID, requiredAddress } = require("./discount-operation-guards");
+
+const REQUIRED_CONTRACTS = ["registry", "arcRegistrar", "circleRegistrar", "arcController", "circleController", "resolver", "reverseRegistrar", "priceOracle", "discountRegistry"];
+const OWNABLE_ABI = ["function owner() view returns (address)"];
+const ACCESS_ABI = ["function hasRole(bytes32,address) view returns (bool)", "function DEFAULT_ADMIN_ROLE() view returns (bytes32)", "function ADMIN_ROLE() view returns (bytes32)", "function PAUSER_ROLE() view returns (bytes32)", "function ORACLE_ROLE() view returns (bytes32)", "function UPGRADER_ROLE() view returns (bytes32)", "function treasury() view returns (address)"];
+
+function loadAssertionConfig(env = process.env) {
+  const config = {
+    adminSafe: requiredAddress(env, "EXPECTED_ADMIN_SAFE_ADDRESS"), timelock: requiredAddress(env, "EXPECTED_TIMELOCK_ADDRESS"),
+    treasury: requiredAddress(env, "EXPECTED_TREASURY_RECIPIENT"), deployer: requiredAddress(env, "EXPECTED_DEPLOYER_ADDRESS"), contracts: {},
+  };
+  let artifact = {};
+  if (env.DEPLOYMENT_ARTIFACT_PATH) artifact = JSON.parse(fs.readFileSync(path.resolve(env.DEPLOYMENT_ARTIFACT_PATH), "utf8")).contracts || {};
+  for (const key of REQUIRED_CONTRACTS) config.contracts[key] = requiredAddress({ value: env[`DEPLOYED_${key.replace(/[A-Z]/g, m => `_${m}`).toUpperCase()}_ADDRESS`] || artifact[key] }, "value");
+  return config;
+}
+
+async function main() {
+  const c = loadAssertionConfig();
+  const { chainId } = await ethers.provider.getNetwork();
+  if (Number(chainId) !== ARC_MAINNET_CHAIN_ID) throw new Error(`Expected Arc mainnet chain ID ${ARC_MAINNET_CHAIN_ID}, received ${chainId}`);
+  for (const [name, address] of Object.entries(c.contracts)) if (await ethers.provider.getCode(address) === "0x") throw new Error(`No bytecode for ${name}`);
+  const eq = (label, actual, expected) => { if (ethers.getAddress(actual) !== expected) throw new Error(`${label} mismatch`); };
+  eq("registry root owner", await new ethers.Contract(c.contracts.registry, ["function owner(bytes32) view returns(address)"], ethers.provider).owner(ethers.ZeroHash), c.adminSafe);
+  for (const key of ["arcRegistrar", "circleRegistrar", "reverseRegistrar", "priceOracle", "discountRegistry"]) eq(`${key} owner`, await new ethers.Contract(c.contracts[key], OWNABLE_ABI, ethers.provider).owner(), c.adminSafe);
+  for (const key of ["arcController", "circleController"]) {
+    const x = new ethers.Contract(c.contracts[key], ACCESS_ABI, ethers.provider);
+    for (const [role, holder] of [[await x.DEFAULT_ADMIN_ROLE(), c.adminSafe], [await x.ADMIN_ROLE(), c.adminSafe], [await x.PAUSER_ROLE(), c.adminSafe], [await x.ORACLE_ROLE(), c.adminSafe], [await x.UPGRADER_ROLE(), c.timelock]]) {
+      if (!(await x.hasRole(role, holder))) throw new Error(`${key} expected holder role assertion failed`);
+      if (c.deployer !== holder && await x.hasRole(role, c.deployer)) throw new Error(`${key} deployer role revocation assertion failed`);
+    }
+    eq(`${key} treasury`, await x.treasury(), c.treasury);
+  }
+  const resolver = new ethers.Contract(c.contracts.resolver, ACCESS_ABI, ethers.provider);
+  for (const [role, holder] of [[await resolver.DEFAULT_ADMIN_ROLE(), c.adminSafe], [await resolver.ADMIN_ROLE(), c.adminSafe], [await resolver.UPGRADER_ROLE(), c.timelock]]) {
+    if (!(await resolver.hasRole(role, holder))) throw new Error("resolver expected holder role assertion failed");
+    if (c.deployer !== holder && await resolver.hasRole(role, c.deployer)) throw new Error("resolver deployer role revocation assertion failed");
+  }
+  console.log("PASS: all configured ownership, role, treasury, and deployer-revocation assertions passed (read-only).");
+}
+
+if (require.main === module) main().catch(e => { console.error(e.message); process.exit(1); });
+module.exports = { loadAssertionConfig, main };

--- a/scripts/mainnet/discount-activate.js
+++ b/scripts/mainnet/discount-activate.js
@@ -1,0 +1,46 @@
+"use strict";
+
+const { ethers } = require("hardhat");
+const {
+  connectExpectedOwner,
+  loadOperationConfig,
+  loadRegistryState,
+} = require("./discount-operation-guards");
+
+const READINESS_FLAGS = [
+  "CONFIRM_CONTRACTS_VERIFIED",
+  "CONFIRM_ADMIN_HANDOFF_ASSERTED",
+  "CONFIRM_INDEXER_READY",
+  "CONFIRM_FRONTEND_CUTOVER_READY",
+  "CONFIRM_PROOF_DELIVERY_READY",
+];
+
+function requireActivationReadiness(env = process.env) {
+  for (const name of READINESS_FLAGS) {
+    if (env[name] !== "YES") throw new Error(`${name}=YES is required before discount activation`);
+  }
+}
+
+async function main() {
+  console.warn("WARNING: WRITE-CAPABLE MAINNET OPERATION — activates only the finalized DiscountRegistry campaign.");
+  requireActivationReadiness();
+  const config = loadOperationConfig("discount-activate");
+  const state = await loadRegistryState(config, ethers.provider);
+
+  if (state.merkleRoot !== config.snapshot.merkleRoot) {
+    throw new Error(`Refusing to activate: expected finalized root ${config.snapshot.merkleRoot}, received ${state.merkleRoot}`);
+  }
+  if (!state.rootFrozen) throw new Error("Refusing to activate: finalized Merkle root is not frozen");
+  if (state.discountActive) throw new Error("Discount campaign is already active; no write is required");
+
+  const registry = await connectExpectedOwner(state.registry, config.expectedOwner);
+  const transaction = await registry.setDiscountActive(true);
+  console.log(`Submitted setDiscountActive transaction: ${transaction.hash}`);
+  await transaction.wait();
+  if (!(await state.registry.discountActive())) throw new Error("Discount activation read-back failed");
+  console.log(`PASS: finalized discount campaign activated at ${config.registryAddress}`);
+}
+
+if (require.main === module) main().catch((error) => { console.error(error.message); process.exit(1); });
+
+module.exports = { READINESS_FLAGS, main, requireActivationReadiness };

--- a/scripts/mainnet/discount-freeze-root.js
+++ b/scripts/mainnet/discount-freeze-root.js
@@ -1,0 +1,32 @@
+"use strict";
+
+const { ethers } = require("hardhat");
+const {
+  connectExpectedOwner,
+  loadOperationConfig,
+  loadRegistryState,
+} = require("./discount-operation-guards");
+
+async function main() {
+  console.warn("WARNING: WRITE-CAPABLE AND IRREVERSIBLE MAINNET OPERATION — freezes only the finalized DiscountRegistry root.");
+  const config = loadOperationConfig("discount-freeze-root");
+  const state = await loadRegistryState(config, ethers.provider);
+
+  if (state.merkleRoot !== config.snapshot.merkleRoot) {
+    throw new Error(`Refusing to freeze: expected finalized root ${config.snapshot.merkleRoot}, received ${state.merkleRoot}`);
+  }
+  if (state.rootFrozen) throw new Error("Finalized Merkle root is already frozen; no write is required");
+  if (state.discountActive) throw new Error("Refusing to freeze: discount campaign is already active");
+
+  const registry = await connectExpectedOwner(state.registry, config.expectedOwner);
+  const transaction = await registry.freezeRoot();
+  console.log(`Submitted freezeRoot transaction: ${transaction.hash}`);
+  await transaction.wait();
+  if (!(await state.registry.rootFrozen())) throw new Error("Root freeze read-back failed");
+  if ((await state.registry.merkleRoot()) !== config.snapshot.merkleRoot) throw new Error("Frozen root read-back mismatch");
+  console.log(`PASS: finalized Merkle root frozen and read back at ${config.registryAddress}`);
+}
+
+if (require.main === module) main().catch((error) => { console.error(error.message); process.exit(1); });
+
+module.exports = { main };

--- a/scripts/mainnet/discount-operation-guards.js
+++ b/scripts/mainnet/discount-operation-guards.js
@@ -1,0 +1,95 @@
+"use strict";
+
+const { ethers } = require("hardhat");
+const { loadAndValidateFinalSnapshot } = require("./final-snapshot");
+
+const ARC_MAINNET_CHAIN_ID = 5042;
+const DISCOUNT_REGISTRY_ABI = [
+  "function owner() view returns (address)",
+  "function campaignId() view returns (bytes32)",
+  "function snapshotBlock() view returns (uint256)",
+  "function merkleRoot() view returns (bytes32)",
+  "function rootFrozen() view returns (bool)",
+  "function discountActive() view returns (bool)",
+  "function setMerkleRoot(bytes32 newRoot)",
+  "function freezeRoot()",
+  "function setDiscountActive(bool active)",
+];
+
+function requiredAddress(env, name) {
+  const value = env[name];
+  if (!value) throw new Error(`${name} is required; no address will be inferred`);
+  if (!ethers.isAddress(value) || value === ethers.ZeroAddress) {
+    throw new Error(`${name} must be a non-zero address`);
+  }
+  return ethers.getAddress(value);
+}
+
+function requireConfirmation(env, operation) {
+  if (env.CONFIRM_MAINNET_WRITE !== "YES") {
+    throw new Error(`CONFIRM_MAINNET_WRITE=YES is required for the write-capable ${operation} operation`);
+  }
+}
+
+function loadOperationConfig(operation, env = process.env, options = {}) {
+  requireConfirmation(env, operation);
+  const snapshot = loadAndValidateFinalSnapshot(env, options.manifestPath);
+  return Object.freeze({
+    operation,
+    snapshot,
+    registryAddress: requiredAddress(env, "DISCOUNT_REGISTRY_ADDRESS"),
+    expectedOwner: requiredAddress(env, "EXPECTED_DISCOUNT_REGISTRY_OWNER"),
+  });
+}
+
+async function assertArcMainnet(provider) {
+  const { chainId } = await provider.getNetwork();
+  if (Number(chainId) !== ARC_MAINNET_CHAIN_ID) {
+    throw new Error(`Expected Arc mainnet chain ID ${ARC_MAINNET_CHAIN_ID}, received ${chainId}`);
+  }
+}
+
+async function loadRegistryState(config, provider) {
+  await assertArcMainnet(provider);
+  const code = await provider.getCode(config.registryAddress);
+  if (code === "0x") throw new Error(`No contract bytecode at DISCOUNT_REGISTRY_ADDRESS ${config.registryAddress}`);
+
+  const registry = new ethers.Contract(config.registryAddress, DISCOUNT_REGISTRY_ABI, provider);
+  const [owner, campaignId, snapshotBlock, merkleRoot, rootFrozen, discountActive] = await Promise.all([
+    registry.owner(),
+    registry.campaignId(),
+    registry.snapshotBlock(),
+    registry.merkleRoot(),
+    registry.rootFrozen(),
+    registry.discountActive(),
+  ]);
+
+  if (ethers.getAddress(owner) !== config.expectedOwner) {
+    throw new Error(`DiscountRegistry owner mismatch: expected ${config.expectedOwner}, received ${owner}`);
+  }
+  if (campaignId !== config.snapshot.campaignIdBytes32) {
+    throw new Error(`DiscountRegistry campaignId mismatch: expected ${config.snapshot.campaignIdBytes32}, received ${campaignId}`);
+  }
+  if (snapshotBlock !== BigInt(config.snapshot.snapshotBlock)) {
+    throw new Error(`DiscountRegistry snapshotBlock mismatch: expected ${config.snapshot.snapshotBlock}, received ${snapshotBlock}`);
+  }
+
+  return { registry, owner: ethers.getAddress(owner), campaignId, snapshotBlock, merkleRoot, rootFrozen, discountActive };
+}
+
+async function connectExpectedOwner(registry, expectedOwner) {
+  const signer = await ethers.provider.getSigner();
+  const signerAddress = ethers.getAddress(await signer.getAddress());
+  if (signerAddress !== expectedOwner) {
+    throw new Error(`Configured signer ${signerAddress} is not EXPECTED_DISCOUNT_REGISTRY_OWNER ${expectedOwner}`);
+  }
+  return registry.connect(signer);
+}
+
+module.exports = {
+  ARC_MAINNET_CHAIN_ID,
+  connectExpectedOwner,
+  loadOperationConfig,
+  loadRegistryState,
+  requiredAddress,
+};

--- a/scripts/mainnet/discount-set-root.js
+++ b/scripts/mainnet/discount-set-root.js
@@ -1,0 +1,35 @@
+"use strict";
+
+const { ethers } = require("hardhat");
+const {
+  connectExpectedOwner,
+  loadOperationConfig,
+  loadRegistryState,
+} = require("./discount-operation-guards");
+
+async function main() {
+  console.warn("WARNING: WRITE-CAPABLE MAINNET OPERATION — sets only the finalized DiscountRegistry Merkle root.");
+  const config = loadOperationConfig("discount-set-root");
+  const state = await loadRegistryState(config, ethers.provider);
+
+  if (state.rootFrozen) throw new Error("Refusing to set root: DiscountRegistry root is already frozen");
+  if (state.discountActive) throw new Error("Refusing to set root: discount campaign is already active");
+  if (state.merkleRoot !== ethers.ZeroHash && state.merkleRoot !== config.snapshot.merkleRoot) {
+    throw new Error(`Refusing to replace unexpected existing root ${state.merkleRoot}`);
+  }
+  if (state.merkleRoot === config.snapshot.merkleRoot) {
+    throw new Error("Finalized Merkle root is already set; no write is required");
+  }
+
+  const registry = await connectExpectedOwner(state.registry, config.expectedOwner);
+  const transaction = await registry.setMerkleRoot(config.snapshot.merkleRoot);
+  console.log(`Submitted setMerkleRoot transaction: ${transaction.hash}`);
+  await transaction.wait();
+  const readBack = await state.registry.merkleRoot();
+  if (readBack !== config.snapshot.merkleRoot) throw new Error(`Merkle root read-back mismatch: ${readBack}`);
+  console.log(`PASS: finalized Merkle root set and read back at ${config.registryAddress}`);
+}
+
+if (require.main === module) main().catch((error) => { console.error(error.message); process.exit(1); });
+
+module.exports = { main };

--- a/scripts/mainnet/final-snapshot.js
+++ b/scripts/mainnet/final-snapshot.js
@@ -1,0 +1,108 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { ethers } = require("ethers");
+
+const FINAL_SNAPSHOT_MANIFEST_PATH = path.resolve(
+  __dirname,
+  "../../snapshots/arc-testnet-v3-early-adopters/manifest.json",
+);
+
+const EXPECTED_FINAL_SNAPSHOT = Object.freeze({
+  campaignId: "ARCNS_TESTNET_V3_EARLY_ADOPTER_2026_V1",
+  campaignIdBytes32: "0xae3c7462e46cc76b3e0349e7d211264ada95257da9d9d7a797abed70b7eb83e3",
+  snapshotBlock: 54933646,
+  snapshotBlockHash: "0x0a450d7fb8055de409084ddb9942f31431aa017a3b3241c4eb8e2e655b8c024d",
+  merkleRoot: "0xf18c50fa221162f76d0b88f21aa26e4211c5a77ee72d4dd58240a40406f38d9e",
+  eligibleWalletCount: 849,
+});
+
+function assertExact(field, actual, expected) {
+  if (actual !== expected) {
+    throw new Error(`Final snapshot manifest mismatch for ${field}: expected ${expected}, received ${actual}`);
+  }
+}
+
+function assertBytes32(field, value) {
+  if (typeof value !== "string" || !ethers.isHexString(value, 32)) {
+    throw new Error(`Final snapshot manifest ${field} must be a bytes32 hex string`);
+  }
+}
+
+function validateFinalSnapshotManifest(manifest) {
+  if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) {
+    throw new Error("Final snapshot manifest must be a JSON object");
+  }
+
+  assertBytes32("campaignIdBytes32", manifest.campaignIdBytes32);
+  assertBytes32("snapshotBlockHash", manifest.snapshotBlockHash);
+  assertBytes32("merkleRoot", manifest.merkleRoot);
+  if (!Number.isSafeInteger(manifest.snapshotBlock) || manifest.snapshotBlock <= 0) {
+    throw new Error("Final snapshot manifest snapshotBlock must be a positive safe integer");
+  }
+  if (!Number.isSafeInteger(manifest.eligibleWalletCount) || manifest.eligibleWalletCount <= 0) {
+    throw new Error("Final snapshot manifest eligibleWalletCount must be a positive safe integer");
+  }
+
+  for (const [field, expected] of Object.entries(EXPECTED_FINAL_SNAPSHOT)) {
+    assertExact(field, manifest[field], expected);
+  }
+
+  const derivedCampaignId = ethers.id(manifest.campaignId);
+  assertExact("campaignIdBytes32 derived from campaignId", derivedCampaignId, manifest.campaignIdBytes32);
+
+  return Object.freeze({ ...EXPECTED_FINAL_SNAPSHOT });
+}
+
+function loadFinalSnapshotManifest(manifestPath = FINAL_SNAPSHOT_MANIFEST_PATH) {
+  let raw;
+  try {
+    raw = fs.readFileSync(manifestPath, "utf8");
+  } catch (error) {
+    throw new Error(`Final snapshot manifest is required and could not be read at ${manifestPath}: ${error.message}`);
+  }
+
+  let manifest;
+  try {
+    manifest = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Final snapshot manifest is malformed JSON at ${manifestPath}: ${error.message}`);
+  }
+
+  return validateFinalSnapshotManifest(manifest);
+}
+
+function validateFinalSnapshotEnv(env, snapshot) {
+  const checks = [
+    ["EARLY_ADOPTER_CAMPAIGN_ID", "campaignId", String],
+    ["EARLY_ADOPTER_CAMPAIGN_ID_BYTES32", "campaignIdBytes32", String],
+    ["EARLY_ADOPTER_SNAPSHOT_BLOCK", "snapshotBlock", Number],
+    ["EARLY_ADOPTER_SNAPSHOT_BLOCK_HASH", "snapshotBlockHash", String],
+    ["EARLY_ADOPTER_MERKLE_ROOT", "merkleRoot", String],
+    ["EARLY_ADOPTER_ELIGIBLE_WALLET_COUNT", "eligibleWalletCount", Number],
+  ];
+
+  for (const [envName, field, convert] of checks) {
+    if (env[envName] === undefined || env[envName] === "") continue;
+    const actual = convert(env[envName]);
+    if (actual !== snapshot[field]) {
+      throw new Error(`${envName} contradicts the finalized snapshot manifest: expected ${snapshot[field]}, received ${env[envName]}`);
+    }
+  }
+
+  return snapshot;
+}
+
+function loadAndValidateFinalSnapshot(env = process.env, manifestPath = FINAL_SNAPSHOT_MANIFEST_PATH) {
+  return validateFinalSnapshotEnv(env, loadFinalSnapshotManifest(manifestPath));
+}
+
+module.exports = {
+  EXPECTED_FINAL_SNAPSHOT,
+  FINAL_SNAPSHOT_MANIFEST_PATH,
+  loadAndValidateFinalSnapshot,
+  loadFinalSnapshotManifest,
+  validateFinalSnapshotEnv,
+  validateFinalSnapshotManifest,
+};

--- a/scripts/v3/deployV3.js
+++ b/scripts/v3/deployV3.js
@@ -24,11 +24,9 @@
  *   TREASURY_ADDRESS  — treasury EOA (defaults to deployer)
  *   PRIVATE_KEY       — deployer private key (from .env)
  *   DEPLOY_EARLY_ADOPTER_DISCOUNT_REGISTRY — true to deploy/wire the shared registry
- *   EARLY_ADOPTER_CAMPAIGN_ID               — required bytes32 or text ID when enabled
- *   EARLY_ADOPTER_SNAPSHOT_BLOCK            — required finalized source block when enabled
- *   EARLY_ADOPTER_MERKLE_ROOT               — optional bytes32 before final snapshot
- *   EARLY_ADOPTER_DISCOUNT_ACTIVE            — defaults false
- *   EARLY_ADOPTER_FREEZE_ROOT                — defaults false
+ *   Campaign facts come only from the finalized snapshot manifest. Supplied
+ *   EARLY_ADOPTER_* fact values must match it exactly. Root set, root freeze,
+ *   and activation are intentionally separate reviewed operations.
  */
 
 "use strict";
@@ -36,6 +34,7 @@
 const { ethers, upgrades, network } = require("hardhat");
 const fs   = require("fs");
 const path = require("path");
+const { loadAndValidateFinalSnapshot } = require("../mainnet/final-snapshot");
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -59,35 +58,36 @@ function envBoolean(value, defaultValue = false) {
   throw new Error(`Expected boolean true/false, received: ${value}`);
 }
 
-function discountDeploymentConfig(env = process.env) {
+function discountDeploymentConfig(env = process.env, options = {}) {
   const enabled = envBoolean(env.DEPLOY_EARLY_ADOPTER_DISCOUNT_REGISTRY, false);
   if (!enabled) return { enabled: false };
 
-  if (!env.EARLY_ADOPTER_CAMPAIGN_ID) throw new Error("EARLY_ADOPTER_CAMPAIGN_ID is required when discount registry deployment is enabled");
-  const snapshotBlock = Number(env.EARLY_ADOPTER_SNAPSHOT_BLOCK);
-  if (!Number.isSafeInteger(snapshotBlock) || snapshotBlock <= 0) {
-    throw new Error("EARLY_ADOPTER_SNAPSHOT_BLOCK must be a positive safe integer when discount registry deployment is enabled");
+  for (const name of ["EARLY_ADOPTER_DISCOUNT_ACTIVE", "EARLY_ADOPTER_FREEZE_ROOT", "EARLY_ADOPTER_SET_ROOT"]) {
+    if (env[name] !== undefined && env[name] !== "" && env[name] !== "false") {
+      throw new Error(`${name} is forbidden in deployV3.js; use the separate reviewed mainnet operation script`);
+    }
   }
-
-  const campaignId = ethers.isHexString(env.EARLY_ADOPTER_CAMPAIGN_ID, 32)
-    ? env.EARLY_ADOPTER_CAMPAIGN_ID
-    : ethers.id(env.EARLY_ADOPTER_CAMPAIGN_ID);
-  const merkleRoot = env.EARLY_ADOPTER_MERKLE_ROOT || null;
-  if (merkleRoot && !ethers.isHexString(merkleRoot, 32)) throw new Error("EARLY_ADOPTER_MERKLE_ROOT must be bytes32");
-
-  const active = envBoolean(env.EARLY_ADOPTER_DISCOUNT_ACTIVE, false);
-  const freezeRoot = envBoolean(env.EARLY_ADOPTER_FREEZE_ROOT, false);
-  if (!merkleRoot && (active || freezeRoot)) {
-    throw new Error("A finalized EARLY_ADOPTER_MERKLE_ROOT is required before freeze or activation");
-  }
-  return { enabled, campaignId, snapshotBlock, merkleRoot, active, freezeRoot };
+  const snapshot = loadAndValidateFinalSnapshot(env, options.manifestPath);
+  return {
+    enabled: true,
+    campaignId: snapshot.campaignIdBytes32,
+    snapshotBlock: snapshot.snapshotBlock,
+    snapshotBlockHash: snapshot.snapshotBlockHash,
+    merkleRoot: snapshot.merkleRoot,
+    eligibleWalletCount: snapshot.eligibleWalletCount,
+    rootSetDuringDeploy: false,
+    rootFrozenDuringDeploy: false,
+    activeDuringDeploy: false,
+  };
 }
 
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
 async function main() {
-  const [deployer] = await ethers.getSigners();
   const isLocal = ["hardhat", "localhost"].includes(network.name);
+  // All environment/manifest checks must finish before a signer is loaded or any write can occur.
+  const discountConfig = discountDeploymentConfig();
+  const [deployer] = await ethers.getSigners();
 
   console.log("\n╔══════════════════════════════════════╗");
   console.log("║   ArcNS v3 — Canonical Deployment    ║");
@@ -97,7 +97,6 @@ async function main() {
   console.log(`Deployer : ${deployer.address}\n`);
 
   const contracts = {};
-  const discountConfig = discountDeploymentConfig();
 
   if (network.name === "arc_mainnet") {
     const expected = [100_000_000n, 50_000_000n, 25_000_000n, 15_000_000n, 5_000_000n];
@@ -285,14 +284,13 @@ async function main() {
     await (await arcController.setDiscountRegistry(contracts.discountRegistry)).wait();
     await (await circleController.setDiscountRegistry(contracts.discountRegistry)).wait();
 
-    if (discountConfig.merkleRoot) await (await discountRegistry.setMerkleRoot(discountConfig.merkleRoot)).wait();
-    if (discountConfig.freezeRoot) await (await discountRegistry.freezeRoot()).wait();
-    if (discountConfig.active) await (await discountRegistry.setDiscountActive(true)).wait();
-
     if (await arcController.discountRegistry() !== contracts.discountRegistry || await circleController.discountRegistry() !== contracts.discountRegistry) {
       throw new Error("Both controllers must point to the same shared discount registry");
     }
-    console.log("   ✓ Shared discount registry authorized and wired to both controllers");
+    if (await discountRegistry.merkleRoot() !== ethers.ZeroHash || await discountRegistry.rootFrozen() || await discountRegistry.discountActive()) {
+      throw new Error("Discount registry deploy/bootstrap must leave root unset, unfrozen, and inactive");
+    }
+    console.log("   ✓ Shared discount registry wired; root remains unset, unfrozen, and inactive");
   }
 
   // ── 12. Save deployment output ─────────────────────────────────────────────

--- a/test/v3/DeploymentPreparation.test.js
+++ b/test/v3/DeploymentPreparation.test.js
@@ -1,31 +1,37 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
 const { discountDeploymentConfig } = require("../../scripts/v3/deployV3");
+const { EXPECTED_FINAL_SNAPSHOT, validateFinalSnapshotManifest } = require("../../scripts/mainnet/final-snapshot");
+const { loadAssertionConfig } = require("../../scripts/mainnet/assert-admin-handoff");
 
 describe("v3 deployment discount preparation", function () {
-  it("is disabled by default and does not require a final root", function () {
+  it("validates the pinned finalized manifest facts", function () {
+    expect(validateFinalSnapshotManifest({ ...EXPECTED_FINAL_SNAPSHOT })).to.deep.equal(EXPECTED_FINAL_SNAPSHOT);
+    for (const [field, value] of [["campaignId", "wrong"], ["campaignIdBytes32", ethers.ZeroHash], ["snapshotBlock", 1], ["merkleRoot", ethers.ZeroHash]]) {
+      expect(() => validateFinalSnapshotManifest({ ...EXPECTED_FINAL_SNAPSHOT, [field]: value })).to.throw();
+    }
+  });
+  it("keeps deployment lifecycle operations disabled", function () {
+    const config = discountDeploymentConfig({ DEPLOY_EARLY_ADOPTER_DISCOUNT_REGISTRY: "true" });
+    expect(config).to.include({ rootSetDuringDeploy: false, rootFrozenDuringDeploy: false, activeDuringDeploy: false });
+    expect(() => discountDeploymentConfig({ DEPLOY_EARLY_ADOPTER_DISCOUNT_REGISTRY: "true", EARLY_ADOPTER_DISCOUNT_ACTIVE: "true" })).to.throw("forbidden");
+  });
+  it("authority assertion fails closed without expected values", function () { expect(() => loadAssertionConfig({})).to.throw("required"); });
+  it("is disabled by default and uses only the finalized manifest when enabled", function () {
     expect(discountDeploymentConfig({})).to.deep.equal({ enabled: false });
-    const config = discountDeploymentConfig({
-      DEPLOY_EARLY_ADOPTER_DISCOUNT_REGISTRY: "true",
-      EARLY_ADOPTER_CAMPAIGN_ID: "campaign-1",
-      EARLY_ADOPTER_SNAPSHOT_BLOCK: "123",
-    });
-    expect(config).to.include({ enabled: true, snapshotBlock: 123, merkleRoot: null, active: false, freezeRoot: false });
-    expect(config.campaignId).to.equal(ethers.id("campaign-1"));
+    const config = discountDeploymentConfig({ DEPLOY_EARLY_ADOPTER_DISCOUNT_REGISTRY: "true" });
+    expect(config.campaignId).to.equal(EXPECTED_FINAL_SNAPSHOT.campaignIdBytes32);
+    expect(config.snapshotBlock).to.equal(EXPECTED_FINAL_SNAPSHOT.snapshotBlock);
   });
 
-  it("requires campaign and snapshot metadata when enabled", function () {
-    expect(() => discountDeploymentConfig({ DEPLOY_EARLY_ADOPTER_DISCOUNT_REGISTRY: "true" })).to.throw("EARLY_ADOPTER_CAMPAIGN_ID");
-    expect(() => discountDeploymentConfig({ DEPLOY_EARLY_ADOPTER_DISCOUNT_REGISTRY: "true", EARLY_ADOPTER_CAMPAIGN_ID: "campaign" })).to.throw("EARLY_ADOPTER_SNAPSHOT_BLOCK");
+  it("rejects environment facts that contradict the finalized manifest", function () {
+    expect(() => discountDeploymentConfig({ DEPLOY_EARLY_ADOPTER_DISCOUNT_REGISTRY: "true", EARLY_ADOPTER_CAMPAIGN_ID: "wrong" })).to.throw("contradicts");
+    expect(() => discountDeploymentConfig({ DEPLOY_EARLY_ADOPTER_DISCOUNT_REGISTRY: "true", EARLY_ADOPTER_SNAPSHOT_BLOCK: "1" })).to.throw("contradicts");
   });
 
-  it("refuses freeze or activation without a finalized root", function () {
-    const common = {
-      DEPLOY_EARLY_ADOPTER_DISCOUNT_REGISTRY: "true",
-      EARLY_ADOPTER_CAMPAIGN_ID: "campaign",
-      EARLY_ADOPTER_SNAPSHOT_BLOCK: "123",
-    };
-    expect(() => discountDeploymentConfig({ ...common, EARLY_ADOPTER_DISCOUNT_ACTIVE: "true" })).to.throw("finalized EARLY_ADOPTER_MERKLE_ROOT");
-    expect(() => discountDeploymentConfig({ ...common, EARLY_ADOPTER_FREEZE_ROOT: "true" })).to.throw("finalized EARLY_ADOPTER_MERKLE_ROOT");
+  it("refuses lifecycle writes in ordinary deployment", function () {
+    const common = { DEPLOY_EARLY_ADOPTER_DISCOUNT_REGISTRY: "true" };
+    expect(() => discountDeploymentConfig({ ...common, EARLY_ADOPTER_DISCOUNT_ACTIVE: "true" })).to.throw("forbidden");
+    expect(() => discountDeploymentConfig({ ...common, EARLY_ADOPTER_FREEZE_ROOT: "true" })).to.throw("forbidden");
   });
 });


### PR DESCRIPTION
This PR implements the Aşama 5A launch-blocking tooling guards identified by the internal focused mainnet launch review.

Included:
- Adds finalized snapshot manifest validation.
- Pins campaign ID, campaign bytes32, snapshot block, block hash, Merkle root, and eligible wallet count to the reviewed manifest.
- Fails closed on missing, malformed, or mismatched campaign facts.
- Hardens deployV3.js so ordinary deployment does not set root, freeze root, or activate discount.
- Splits discount lifecycle operations into separate guarded scripts:
  - discount-set-root
  - discount-freeze-root
  - discount-activate
- Adds read-only admin handoff assertion tooling.
- Updates mainnet docs and checklist to reflect the separated lifecycle and required handoff verification.
- Adds tests for pinned snapshot facts, mismatch rejection, lifecycle separation, and missing assertion inputs.

Not included:
- No deployment.
- No live on-chain write.
- No signing.
- No price update.
- No Merkle root set/freeze/activation.
- No ownership or role transfer.
- No Safe or Timelock creation.
- No frontend mainnet switch.
- No real deployment artifact change.
- No env, private key, or secret changes.

Validation:
- git diff --check passed.
- JavaScript syntax checks passed.
- Hardhat compile passed.
- DeploymentPreparation tests passed.
- SnapshotGenerator tests passed.
- DiscountRegistry tests passed.
- Controller tests passed.

Remaining blockers:
- Final Admin Safe address, owners, and threshold.
- 48-hour Timelock deployment and configuration.
- Actual handoff and deployer revocation.
- Deploy-grade RPC.
- Blockscout verification workflow.
- Mainnet indexer/subgraph.
- Frontend mainnet/discount cutover.
- Final human review before any mainnet deployment.