### PR TITLE
docs: add mainnet deploy infrastructure readiness plan

### DIFF
--- a/docs/mainnet/DEPLOYMENT_RUNBOOK.md
+++ b/docs/mainnet/DEPLOYMENT_RUNBOOK.md
@@ -6,6 +6,8 @@ The finalized launch authority model and unresolved administration blockers are 
 
 The future Safe / Timelock / deployer-revocation ceremony and its read-only verification inputs are documented in [`HANDOFF_CEREMONY_PLAN.md`](./HANDOFF_CEREMONY_PLAN.md).
 
+Deploy-grade RPC acceptance and Blockscout verification blockers are tracked in [`DEPLOY_INFRA_READINESS.md`](./DEPLOY_INFRA_READINESS.md).
+
 Arc mainnet target: chain ID `5042`, deploy-grade RPC still to be finalized (the previously listed `https://rpc.blockdaemon.mainnet.arc.io` endpoint remains a candidate pending approval), explorer `https://arc-mainnet.cloud.blockscout.com`, native symbol `USDC`, USDC `0x3600000000000000000000000000000000000000`. The confirmed `https://radar-api-rpc.up.railway.app` endpoint is a read-only/testing fallback only and is not deployment-grade RPC.
 
 1. Confirm a separately approved deployer and treasury configuration; never place credentials in source.

--- a/docs/mainnet/DEPLOY_INFRA_READINESS.md
+++ b/docs/mainnet/DEPLOY_INFRA_READINESS.md
@@ -1,0 +1,95 @@
+# Arc Mainnet Deploy Infrastructure Readiness (Aşama 5C)
+
+Status: read-only infrastructure preparation. This document records acceptance criteria and current evidence; it does not approve or execute deployment.
+
+## Executive summary
+
+- An explicitly approved deploy-grade RPC is a launch blocker.
+- `https://radar-api-rpc.up.railway.app` remains a read-only/testing fallback only.
+- The Blockscout verification path must be validated before deployment.
+- This document does not approve mainnet deployment.
+
+## RPC endpoint classification
+
+| Endpoint | Classification | Evidence | Allowed use | Launch blocker? |
+|---|---|---|---|---|
+| Blockdaemon authorized RPC | Candidate / `TBD` | Public request returned `401`; an authorized endpoint has not passed the complete checklist | None until authorization, testing, and explicit approval | Yes |
+| Radar RPC | Read-only/testing fallback only | Extended three-attempt read check and Hardhat preflight passed on 2026-08-03: chain `5042`, latest block data, USDC code/metadata, gas price, fee history, and provider fee data; not approved for signing or deployment | Read-only diagnostics and fallback reads | Yes — a primary is still required |
+| Thirdweb public endpoint | Not deploy-grade | Returned chain ID but failed deeper reads | None for signing/deployment | Yes |
+| Infura / Alchemy project endpoint | Candidate only | Prior demo/project paths were not deploy-ready; Arc access and complete checks remain unproven | None until project-specific approval and checks pass | Yes |
+
+No secret or tokenized URL is recorded here. Deployment evidence must mask credentials and query strings.
+
+## Deploy-grade RPC acceptance criteria
+
+An endpoint is not approved merely because a readiness script passes. Approval requires all of the following:
+
+- [ ] Provider is authorized or the endpoint is explicitly approved.
+- [ ] Endpoint uses HTTPS only.
+- [ ] Endpoint is not backed by a public, demo, or shared key.
+- [ ] No community endpoint is used for signing or deployment.
+- [ ] `eth_chainId` returns `5042`.
+- [ ] Latest block number can be fetched.
+- [ ] `eth_getBlockByNumber` for latest returns valid block data.
+- [ ] `eth_getCode` returns non-empty bytecode for Arc USDC `0x3600000000000000000000000000000000000000`.
+- [ ] `eth_call` returns `USDC` for `symbol()` and `6` for `decimals()`.
+- [ ] `eth_gasPrice` works.
+- [ ] `eth_feeHistory` works when supported; lack of support is recorded rather than misreported.
+- [ ] ethers/Hardhat provider fee data works when available.
+- [ ] Key reads are stable across at least three attempts.
+- [ ] `npx hardhat run scripts/preflight-arc-mainnet.js --network arc_mainnet` passes.
+- [ ] No secret must be committed to the repository.
+- [ ] The RPC is supplied only through a temporary shell environment or approved secret manager during deployment.
+- [ ] At least one primary deploy RPC and one read-only fallback are available before deployment.
+- [ ] The deployment ceremony stops if the primary fails or returns inconsistent chain data.
+
+Read-only extended check: `node scripts/mainnet/check-rpc-readiness.js`. A `readiness-passed` result is evidence only and is not automatic deploy-RPC approval.
+
+## Blockscout verification readiness
+
+- **Browser URL:** `https://arc-mainnet.cloud.blockscout.com`
+- **Candidate API URL:** `https://arc-mainnet.cloud.blockscout.com/api` was tested as a legacy candidate and returned HTML/`404`, not JSON. It is not a validated Hardhat verification API. A separate final candidate must be supplied through `ARC_MAINNET_EXPLORER_API_URL`. No secret URL belongs in source or documentation.
+- **Hardhat config:** `hardhat.config.js` has `etherscan.customChains` for `arc_mainnet`, chain ID `5042`, the browser URL above, and an environment-driven API URL. Mainnet does not currently have an explicit `etherscan.apiKey` entry.
+- **API key:** unresolved. Blockscout deployments may permit a placeholder/no key or may require a provider-issued key; confirm against the final API. Never store it in source.
+- **API reachability:** browser-host candidates `/api` and `/api/v2/stats` both failed harmless JSON reachability checks with HTML/`404`. No Etherscan/Hardhat-compatible endpoint was established. Use `node scripts/mainnet/check-blockscout-readiness.js` for harmless JSON reachability/classification checks when the explorer operator supplies a candidate.
+- **Hardhat preparation:** compiler `0.8.26`, optimizer enabled with 200 runs, `viaIR: true`, and `evmVersion: cancun` are configured, so verification commands can be prepared without deploying or submitting a verification request.
+- **Proxy verification:** proxy addresses may require a separate Blockscout proxy-association or proxy-verification process after implementation source verification. Confirm the final explorer workflow before deployment.
+- **Known uncertainties:** exact API URL/version, API-key policy, Hardhat plugin compatibility, proxy-association workflow, and response behavior remain unresolved. HTML returned from a candidate API is not valid API evidence.
+
+Preserve constructor arguments for directly deployed contracts. For proxies, preserve proxy type, proxy address, implementation address, initializer calldata/arguments, implementation constructor arguments where applicable, and every upgrade plugin manifest/artifact needed to reproduce the relationship. Preserve linked-library addresses if any.
+
+## Required deployment-time evidence
+
+- Exact RPC provider used, with URL credentials and query strings masked
+- Chain ID observed
+- Latest block immediately before deployment
+- Deployer address
+- All deployed addresses
+- Implementation addresses for proxies
+- Constructor arguments
+- Initializer arguments and calldata
+- Library addresses, if any
+- Compiler version
+- Optimizer and EVM settings
+- Commit hash
+- Deployment artifact path
+- Exact verification command used
+- Verification result URLs
+
+## Remaining blockers
+
+- [ ] Deploy-grade RPC approval
+- [ ] Blockscout API validation
+- [ ] Final Safe and Timelock addresses
+- [ ] Actual authority handoff execution and read-only confirmation
+- [ ] Mainnet indexer/subgraph
+- [ ] Frontend cutover
+- [ ] Final launch review
+
+## Non-goals and safety boundary
+
+- This document does not deploy contracts.
+- This document does not verify contracts.
+- This document does not approve mainnet launch.
+- This document does not modify frontend production config.
+- This phase does not sign, submit transactions, call write functions, create a Safe, deploy a Timelock, transfer ownership, change roles, change prices, change a Merkle root, or activate a discount.

--- a/docs/mainnet/FOCUSED_SECURITY_REVIEW.md
+++ b/docs/mainnet/FOCUSED_SECURITY_REVIEW.md
@@ -2,6 +2,8 @@
 
 Status: internal focused review completed on branch `security/focused-mainnet-launch-review`.
 
+Current deploy-grade RPC and Blockscout verification readiness is tracked in [`DEPLOY_INFRA_READINESS.md`](./DEPLOY_INFRA_READINESS.md).
+
 Remediation status: FSR-02 and FSR-06 are addressed by the Aşama 5A tooling guards. FSR-01 is partially addressed by a fail-closed read-only handoff assertion; final Safe/Timelock creation, handoff execution, and verification remain launch actions and blockers.
 
 This is an **internal focused review**, **not an external audit**. Mainnet deployment remains blocked until the blockers listed below are resolved and independently rechecked. No deployment, Arc on-chain write, signing, ownership transfer, role change, price update, Merkle-root update, campaign activation, production frontend switch, staging, commit, or push was performed by this review.

--- a/docs/mainnet/SECURITY_CHECKLIST.md
+++ b/docs/mainnet/SECURITY_CHECKLIST.md
@@ -1,5 +1,7 @@
 # Mainnet Security Checklist
 
+Infrastructure acceptance evidence: [`DEPLOY_INFRA_READINESS.md`](./DEPLOY_INFRA_READINESS.md).
+
 - [ ] Confirm every ownership, admin, upgrade, pause, treasury, and deployer-revocation item in [`ADMIN_OWNERSHIP_PLAN.md`](./ADMIN_OWNERSHIP_PLAN.md).
 - [ ] Execute and verify the separately reviewed future ceremony in [`HANDOFF_CEREMONY_PLAN.md`](./HANDOFF_CEREMONY_PLAN.md) before launch.
 - [ ] Confirm standard oracle reads are 100/50/25/15/5 USDC in p1..p5 order.

--- a/scripts/mainnet/check-blockscout-readiness.js
+++ b/scripts/mainnet/check-blockscout-readiness.js
@@ -1,0 +1,50 @@
+"use strict";
+
+const PLACEHOLDERS = ["", "undefined", "null", "<api_url>", "<tbd>", "your_api_url"];
+
+function getApiUrl(env = process.env) {
+  const value = String(env.ARC_MAINNET_EXPLORER_API_URL || "").trim();
+  const normalized = value.toLowerCase();
+  if (PLACEHOLDERS.includes(normalized) || normalized.includes("<") || normalized.includes("example")) throw new Error("ARC_MAINNET_EXPLORER_API_URL must be a real endpoint, not an empty or placeholder value");
+  let parsed;
+  try { parsed = new URL(value); } catch { throw new Error("ARC_MAINNET_EXPLORER_API_URL must be a valid HTTPS URL"); }
+  if (parsed.protocol !== "https:") throw new Error("ARC_MAINNET_EXPLORER_API_URL must use HTTPS");
+  return value;
+}
+
+function maskedUrl(value) {
+  const parsed = new URL(value);
+  parsed.username = parsed.username ? "***" : "";
+  parsed.password = parsed.password ? "***" : "";
+  if (parsed.pathname !== "/") parsed.pathname = "/***";
+  if ([...parsed.searchParams.keys()].length) parsed.search = "?***=masked";
+  return parsed.toString().replace(/\/$/, "");
+}
+
+function safeErrorMessage(error) {
+  return String(error?.message || error || "unknown error").replace(/https:\/\/[^\s)\]}]+/gi, "[masked URL]");
+}
+
+async function main() {
+  const url = getApiUrl();
+  const response = await fetch(url, { method: "GET", headers: { accept: "application/json" } });
+  const contentType = response.headers.get("content-type") || "";
+  const body = await response.text();
+  let ready = false;
+  if (!contentType.toLowerCase().includes("json") || /^\s*<!doctype html|^\s*<html/i.test(body)) {
+    console.log(`UNRESOLVED: endpoint reachable but did not return JSON (${response.status})`);
+  } else {
+    let parsed;
+    try { parsed = JSON.parse(body); } catch { parsed = null; }
+    const blockscout = /blockscout/i.test(body);
+    const etherscan = parsed && (Object.prototype.hasOwnProperty.call(parsed, "status") || Object.prototype.hasOwnProperty.call(parsed, "message"));
+    const classification = blockscout ? "Blockscout-compatible" : etherscan ? "Etherscan-compatible" : "unresolved";
+    ready = response.ok && classification !== "unresolved";
+    console.log(`${ready ? "PASS" : "UNRESOLVED"}: endpoint returned JSON; classification: ${classification} (reachability only, no verification request)`);
+  }
+  console.log(`Endpoint: ${maskedUrl(url)}`);
+  if (!ready) process.exitCode = 1;
+}
+
+if (require.main === module) main().catch((error) => { console.error(`FAIL: ${safeErrorMessage(error)}`); process.exit(1); });
+module.exports = { getApiUrl, maskedUrl, safeErrorMessage, main };

--- a/scripts/mainnet/check-rpc-readiness.js
+++ b/scripts/mainnet/check-rpc-readiness.js
@@ -1,0 +1,93 @@
+"use strict";
+
+const { ethers } = require("ethers");
+
+const EXPECTED_CHAIN_ID = 5042;
+const USDC_ADDRESS = "0x3600000000000000000000000000000000000000";
+const READ_ATTEMPTS = 3;
+const PLACEHOLDERS = ["", "undefined", "null", "<rpc_url>", "<tbd>", "your_rpc_url"];
+
+function getRpcUrl(env = process.env) {
+  const value = String(env.ARC_MAINNET_RPC_URL || "").trim();
+  const normalized = value.toLowerCase();
+  if (PLACEHOLDERS.includes(normalized) || normalized.includes("<") || normalized.includes("example")) {
+    throw new Error("ARC_MAINNET_RPC_URL must be a real HTTPS endpoint, not an empty or placeholder value");
+  }
+  let parsed;
+  try { parsed = new URL(value); } catch { throw new Error("ARC_MAINNET_RPC_URL must be a valid HTTPS URL"); }
+  if (parsed.protocol !== "https:") throw new Error("ARC_MAINNET_RPC_URL must use HTTPS");
+  return value;
+}
+
+function maskedUrl(value) {
+  const parsed = new URL(value);
+  parsed.username = parsed.username ? "***" : "";
+  parsed.password = parsed.password ? "***" : "";
+  if (parsed.pathname !== "/") parsed.pathname = "/***";
+  if ([...parsed.searchParams.keys()].length) parsed.search = "?***=masked";
+  return parsed.toString().replace(/\/$/, "");
+}
+
+function safeErrorMessage(error) {
+  return String(error?.message || error || "unknown error").replace(/https:\/\/[^\s)\]}]+/gi, "[masked URL]");
+}
+
+async function repeat(label, operation) {
+  const values = [];
+  for (let i = 0; i < READ_ATTEMPTS; i += 1) values.push(await operation());
+  const serialized = values.map((value) => JSON.stringify(value, (_, item) => typeof item === "bigint" ? item.toString() : item));
+  if (serialized.some((value) => value !== serialized[0])) throw new Error(`${label} was not stable across ${READ_ATTEMPTS} attempts`);
+  return values[0];
+}
+
+async function repeatLatestBlocks(provider) {
+  const blocks = [];
+  for (let i = 0; i < READ_ATTEMPTS; i += 1) {
+    const blockNumber = await provider.getBlockNumber();
+    const block = await provider.getBlock(blockNumber);
+    if (!block || block.number !== blockNumber || !block.hash) throw new Error(`Latest block attempt ${i + 1} returned invalid data`);
+    blocks.push(block);
+  }
+  for (let i = 1; i < blocks.length; i += 1) {
+    if (blocks[i].number < blocks[i - 1].number) throw new Error("Latest block number moved backwards across attempts");
+    if (blocks[i].number === blocks[i - 1].number && blocks[i].hash !== blocks[i - 1].hash) throw new Error("Latest block hash was inconsistent across attempts");
+  }
+  return blocks.at(-1);
+}
+
+async function repeatValid(label, operation, validate) {
+  const values = [];
+  for (let i = 0; i < READ_ATTEMPTS; i += 1) {
+    const value = await operation();
+    if (!validate(value)) throw new Error(`${label} attempt ${i + 1} returned invalid data`);
+    values.push(value);
+  }
+  return values.at(-1);
+}
+
+async function main() {
+  const url = getRpcUrl();
+  const provider = new ethers.JsonRpcProvider(url, EXPECTED_CHAIN_ID, { staticNetwork: true, batchMaxCount: 1 });
+  const network = await provider.getNetwork();
+  if (Number(network.chainId) !== EXPECTED_CHAIN_ID) throw new Error(`Expected chain ID ${EXPECTED_CHAIN_ID}, received ${network.chainId}`);
+  const block = await repeatLatestBlocks(provider);
+  const code = await repeat("USDC bytecode", () => provider.getCode(USDC_ADDRESS));
+  if (code === "0x") throw new Error("Arc mainnet USDC has no bytecode");
+  const usdc = new ethers.Contract(USDC_ADDRESS, ["function symbol() view returns (string)", "function decimals() view returns (uint8)"], provider);
+  if (await repeat("USDC symbol", () => usdc.symbol()) !== "USDC") throw new Error("USDC symbol check failed");
+  if (Number(await repeat("USDC decimals", () => usdc.decimals())) !== 6) throw new Error("USDC decimals check failed");
+  await repeatValid("gas price", () => provider.send("eth_gasPrice", []), (value) => /^0x[0-9a-f]+$/i.test(value) && BigInt(value) > 0n);
+  let feeHistory = "unsupported";
+  try { feeHistory = await repeatValid("fee history", () => provider.send("eth_feeHistory", ["0x3", "latest", [25, 50, 75]]), (value) => value && Array.isArray(value.baseFeePerGas)); } catch (error) { console.log(`INFO: eth_feeHistory unsupported or unavailable (${safeErrorMessage(error)})`); }
+  const feeData = await repeatValid("provider fee data", () => provider.getFeeData(), (value) => value && (value.gasPrice !== null || value.maxFeePerGas !== null));
+  if (!feeData || (!feeData.gasPrice && !feeData.maxFeePerGas)) throw new Error("Provider fee data is unavailable");
+  console.log("PASS: RPC readiness-passed (read-only checks only; not automatic deploy-RPC approval)");
+  console.log(`Endpoint: ${maskedUrl(url)}`);
+  console.log(`Chain ID: ${network.chainId}`);
+  console.log(`Latest block: ${block.number}`);
+  console.log(`USDC bytecode/symbol/decimals: present / USDC / 6`);
+  console.log(`Fee data: gasPrice / ${feeHistory === "unsupported" ? "feeHistory unsupported" : "feeHistory supported"} / provider fee data`);
+}
+
+if (require.main === module) main().catch((error) => { console.error(`FAIL: ${safeErrorMessage(error)}`); process.exit(1); });
+module.exports = { getRpcUrl, maskedUrl, safeErrorMessage, main, repeat, repeatLatestBlocks, repeatValid };


### PR DESCRIPTION
This PR adds Aşama 5C deploy infrastructure readiness documentation and read-only tooling for ArcNS mainnet deployment preparation.

Included:
- Adds docs/mainnet/DEPLOY_INFRA_READINESS.md.
- Documents deploy-grade RPC acceptance criteria.
- Classifies tested/candidate RPC endpoints.
- Keeps Radar classified as read-only/testing fallback only.
- Documents that deploy-grade RPC remains unresolved.
- Documents Blockscout verification readiness and unresolved API compatibility.
- Adds required deployment-time evidence checklist.
- Adds read-only RPC readiness checker.
- Adds read-only Blockscout/API reachability checker.
- Adds cross-links from the deployment runbook, security checklist, and focused security review.

Not approved:
- Deploy-grade RPC is not approved.
- Blockscout verification path is not approved.
- Mainnet deployment is not approved.

Not included:
- No deployment.
- No live on-chain write.
- No signing.
- No contract verification submission.
- No Safe or Timelock action.
- No ownership or role transfer.
- No price update.
- No Merkle root set/freeze/activation.
- No frontend mainnet switch.
- No deployment artifact change.
- No env, private key, or secret changes.

Validation:
- git diff --check passed.
- Restricted terminology scan passed.
- node --check passed for both added scripts.
- Existing read-only Arc mainnet preflight passed using temporary fallback RPC.
- No deployment scripts, write-capable scripts, or hardhat verify commands were run.

Remaining blockers:
- Explicit approval of an authorized deploy-grade RPC.
- Primary deploy RPC plus separate read-only fallback.
- Final Blockscout API URL, compatibility, and API-key policy.
- Safe and Timelock addresses.
- Handoff execution and read-only confirmation.
- Mainnet indexer/subgraph readiness.
- Frontend mainnet/discount cutover.
- Final launch review.