### PR TITLE
docs: add mainnet indexer subgraph readiness plan

### DIFF
--- a/docs/mainnet/DEPLOYMENT_RUNBOOK.md
+++ b/docs/mainnet/DEPLOYMENT_RUNBOOK.md
@@ -8,6 +8,8 @@ The future Safe / Timelock / deployer-revocation ceremony and its read-only veri
 
 Deploy-grade RPC acceptance and Blockscout verification blockers are tracked in [`DEPLOY_INFRA_READINESS.md`](./DEPLOY_INFRA_READINESS.md).
 
+Mainnet indexer/subgraph inputs, event coverage, and frontend readiness gates are tracked in [`INDEXER_SUBGRAPH_PLAN.md`](./INDEXER_SUBGRAPH_PLAN.md).
+
 Arc mainnet target: chain ID `5042`, deploy-grade RPC still to be finalized (the previously listed `https://rpc.blockdaemon.mainnet.arc.io` endpoint remains a candidate pending approval), explorer `https://arc-mainnet.cloud.blockscout.com`, native symbol `USDC`, USDC `0x3600000000000000000000000000000000000000`. The confirmed `https://radar-api-rpc.up.railway.app` endpoint is a read-only/testing fallback only and is not deployment-grade RPC.
 
 1. Confirm a separately approved deployer and treasury configuration; never place credentials in source.

--- a/docs/mainnet/DEPLOY_INFRA_READINESS.md
+++ b/docs/mainnet/DEPLOY_INFRA_READINESS.md
@@ -7,6 +7,7 @@ Status: read-only infrastructure preparation. This document records acceptance c
 - An explicitly approved deploy-grade RPC is a launch blocker.
 - `https://radar-api-rpc.up.railway.app` remains a read-only/testing fallback only.
 - The Blockscout verification path must be validated before deployment.
+- Mainnet indexer/subgraph readiness is tracked in [`INDEXER_SUBGRAPH_PLAN.md`](./INDEXER_SUBGRAPH_PLAN.md).
 - This document does not approve mainnet deployment.
 
 ## RPC endpoint classification

--- a/docs/mainnet/FOCUSED_SECURITY_REVIEW.md
+++ b/docs/mainnet/FOCUSED_SECURITY_REVIEW.md
@@ -4,6 +4,8 @@ Status: internal focused review completed on branch `security/focused-mainnet-la
 
 Current deploy-grade RPC and Blockscout verification readiness is tracked in [`DEPLOY_INFRA_READINESS.md`](./DEPLOY_INFRA_READINESS.md).
 
+The follow-on mainnet indexer/subgraph readiness plan is tracked in [`INDEXER_SUBGRAPH_PLAN.md`](./INDEXER_SUBGRAPH_PLAN.md).
+
 Remediation status: FSR-02 and FSR-06 are addressed by the Aşama 5A tooling guards. FSR-01 is partially addressed by a fail-closed read-only handoff assertion; final Safe/Timelock creation, handoff execution, and verification remain launch actions and blockers.
 
 This is an **internal focused review**, **not an external audit**. Mainnet deployment remains blocked until the blockers listed below are resolved and independently rechecked. No deployment, Arc on-chain write, signing, ownership transfer, role change, price update, Merkle-root update, campaign activation, production frontend switch, staging, commit, or push was performed by this review.

--- a/docs/mainnet/INDEXER_SUBGRAPH_PLAN.md
+++ b/docs/mainnet/INDEXER_SUBGRAPH_PLAN.md
@@ -1,0 +1,186 @@
+# ArcNS Mainnet Indexer / Subgraph Readiness Plan (Aşama 5D)
+
+> **Readiness plan only.** This document records the inputs, event coverage, deployment sequence, and acceptance evidence required for a future mainnet indexer/subgraph deployment. It does not deploy contracts, deploy a subgraph, create an endpoint, or approve mainnet launch.
+
+## A. Executive summary
+
+The mainnet indexer/subgraph remains a **launch blocker** until a mainnet deployment has been configured with final addresses and start blocks, deployed, synchronized, queried successfully, and compared with direct chain reads. No mainnet subgraph endpoint is approved at this time.
+
+Mainnet contract addresses and deployment start blocks remain `TBD` until the final deployment. Existing ArcNS v3 testnet manifests and `deployments/arc_testnet-v3.json` are historical references only; their addresses and blocks must not be copied into a mainnet manifest. Frontend mainnet cutover must wait for the readiness gates in this document and must be a separate reviewed change.
+
+Known network facts are chain ID `5042`, USDC address `0x3600000000000000000000000000000000000000`, symbol `USDC`, and decimals `6`. Deploy-grade RPC and the Blockscout verification path are not approved.
+
+## B. Required mainnet indexer inputs
+
+| Input | Required value | Source | Status | Notes |
+|---|---|---|---|---|
+| Chain ID | `5042` | Approved mainnet network facts | Known | Must be asserted by the provider before deployment. |
+| Deploy-grade RPC | `TBD` | Approved infrastructure evidence | Blocked | The read-only/testing fallback is not deployment-grade. |
+| Indexer RPC | `TBD` | Selected provider or self-hosted node | Blocked | Must provide stable historical reads and operational ownership. |
+| Registry address | `TBD` | Final deployment record | Blocked | Do not use a testnet address. |
+| `.arc` registrar address | `TBD` | Final deployment record | Blocked |  |
+| `.circle` registrar address | `TBD` | Final deployment record | Blocked |  |
+| `.arc` controller address | `TBD` | Final deployment record | Blocked |  |
+| `.circle` controller address | `TBD` | Final deployment record | Blocked |  |
+| Resolver address | `TBD` | Final deployment record | Blocked |  |
+| Reverse registrar address | `TBD` | Final deployment record | Blocked |  |
+| Price oracle address, if indexed | `TBD` | Final deployment record | TBD | Index only if the final schema and product queries require it. |
+| Discount registry address | `TBD` | Final deployment record | Blocked | Shared registry address must be recorded once final. |
+| Deployment block for registry | `TBD` | Deployment receipt/block reference | Blocked | Record block hash when available. |
+| Deployment block for `.arc` registrar | `TBD` | Deployment receipt/block reference | Blocked |  |
+| Deployment block for `.circle` registrar | `TBD` | Deployment receipt/block reference | Blocked |  |
+| Deployment block for `.arc` controller | `TBD` | Deployment receipt/block reference | Blocked |  |
+| Deployment block for `.circle` controller | `TBD` | Deployment receipt/block reference | Blocked |  |
+| Deployment block for resolver | `TBD` | Deployment receipt/block reference | Blocked |  |
+| Deployment block for reverse registrar | `TBD` | Deployment receipt/block reference | Blocked |  |
+| Deployment block for discount registry | `TBD` | Deployment receipt/block reference | Blocked |  |
+| Verified ABI/artifact source | `TBD` | Final verified source and deployment artifacts | Blocked | ABI must match deployed bytecode/source. |
+| Subgraph deployment target | `TBD` | Reviewed provider/self-hosted decision | Blocked | No target has been selected or approved. |
+| Subgraph endpoint | `TBD` | Provider deployment output | Blocked | Do not invent or reuse a testnet endpoint. |
+| Frontend GraphQL endpoint | `TBD` | Separate frontend cutover review | Blocked | Must not point mainnet at testnet data. |
+| Sync health endpoint or monitoring method | `TBD` | Provider/self-hosted operations | Blocked | Must expose indexed block, lag, and handler/query health. |
+
+## C. Data sources and event coverage
+
+The current `indexer/` package is a testnet-oriented Graph Protocol project. Its manifest and mappings provide the required shape, not mainnet readiness proof. The final mainnet manifest must use final addresses and exact deployment blocks.
+
+### Required sources and currently observed coverage
+
+| Contract/source | Events to cover | Current reference coverage | Mainnet action/status |
+|---|---|---|---|
+| Registry | `Transfer`, `NewResolver` | `indexer/src/registry.ts` handles both | Rebind to final registry address and start block. |
+| `.arc` / `.circle` controllers | `NameRegistered`, `NameRenewed` | `indexer/src/controller.ts` handles both namespaces | Rebind both controller sources and validate ABI/event signatures. |
+| `.arc` / `.circle` registrars/NFTs | ERC-721 `Transfer` | `indexer/src/registrar.ts` handles ownership transfers and skips mints | Rebind both registrar sources; confirm token ID/labelhash behavior. |
+| Resolver | `AddrChanged`, `NameChanged` | `indexer/src/resolver.ts` handles address and name updates | Include if frontend resolution/reverse data depends on indexed state. |
+| Reverse registrar | `ReverseClaimed` | `indexer/src/reverseRegistrar.ts` handles reverse claims | Include if frontend reverse records depend on indexed state. |
+| DiscountRegistry | `DiscountRootUpdated`, `DiscountRootFrozen`, `DiscountActiveUpdated`, `DiscountControllerAuthorizationUpdated`, `DiscountUsed` | No DiscountRegistry data source, schema entities, or mapping handlers are present in the current indexer reference | **Coverage gap.** Add and review exact ABI/schema/handlers after final contract ABI is available; do not treat the current indexer as discount readiness. |
+| Ownership/admin sources | Contract-specific ownership and role events, if present | Not currently a dedicated source | Add only where useful for operational monitoring and only after confirming exact ABI event names. |
+
+The final event inventory must be generated from the verified mainnet ABIs. If a needed event does not exist on the deployed contract, record it as a gap and define a direct-read or alternate monitoring path rather than inventing an event or handler.
+
+The current schema supports domains, accounts, registrations, renewals, domain events, resolver records, reverse records, and labelhash lookup. Before deployment, verify that the schema supports the required counts and discount lifecycle queries. In particular, DiscountRegistry entities/events are not yet represented by the current reference schema.
+
+## D. Mainnet subgraph deployment sequence (dry run)
+
+1. Wait for final mainnet contract deployment.
+2. Record every deployed address and its deployment block number; preserve the block hash where available.
+3. Generate or update the mainnet subgraph manifest with final addresses and start blocks.
+4. Validate that every configured ABI matches the deployed bytecode and verified source.
+5. Deploy the subgraph to the selected provider or self-hosted graph node. This is a future operation, not performed by this phase.
+6. Monitor indexing until synchronized or within the explicitly approved lag budget.
+7. Run query smoke tests against the final endpoint.
+8. Compare indexed totals and sample records with direct read-only chain queries.
+9. Confirm DiscountRegistry lifecycle and consumption events are indexed after the separately reviewed root lifecycle operations.
+10. Only after all evidence passes, allow frontend mainnet endpoint configuration in a separate reviewed PR.
+
+## E. Start block policy
+
+- Use the exact deployment block for each contract whenever possible.
+- Use a small safety buffer only when required by the selected indexer/provider; record the size and the provider-specific reason in the deployment evidence.
+- Do not start from genesis unless a specific, reviewed historical-data requirement justifies it.
+- Never use testnet start blocks on mainnet.
+- Record the deployment block hash when available so the source of each start block is independently auditable.
+- If a proxy or upgradeable contract is used, record the relevant proxy and implementation deployment blocks and the event-source decision explicitly.
+
+## F. Readiness gates
+
+| Gate | Required evidence | Status | Blocks frontend cutover? |
+|---|---|---|---|
+| Subgraph manifest uses final mainnet addresses | Reviewed manifest diff and deployment record | `TBD` | Yes |
+| Start blocks are final | Per-contract receipt/block references, preferably hashes | `TBD` | Yes |
+| ABIs match deployed bytecode/source | Verified artifacts and ABI comparison | `TBD` | Yes |
+| Subgraph deployed successfully | Provider/self-hosted deployment result | `TBD` | Yes |
+| Subgraph synced to latest or acceptable lag | Indexed block and approved lag evidence | `TBD` | Yes |
+| Query smoke tests pass | Saved query results and timestamps | `TBD` | Yes |
+| Registered-name counts are plausible | Comparison with direct chain samples/independent totals | `TBD` | Yes |
+| Holder counts are plausible | Owner-count comparison and sample checks | `TBD` | Yes |
+| Renewals are indexed | Known renewal samples match chain logs | `TBD` | Yes |
+| DiscountRegistry lifecycle events are indexed | Root, freeze, active-state, and authorization event samples | `TBD` | Yes if discount UX is planned |
+| Discount consumption events are indexed | `DiscountUsed` samples match chain logs | `TBD` | Yes if discount UX is planned |
+| Frontend can query names by owner | Query result against known read-only sample | `TBD` | Yes |
+| Frontend can query name availability/status if applicable | Final schema query and direct-read comparison | `TBD` | Yes |
+| Fallback direct-read path is defined if subgraph lags | Read-only RPC fallback behavior and UX decision | `TBD` | Yes |
+| Monitoring/alerting is defined | Owner, thresholds, alerts, and incident procedure | `TBD` | Yes |
+
+## G. Smoke query checklist
+
+Run these against the final endpoint only after the schema and endpoint are approved. The endpoint is intentionally a placeholder here:
+
+```text
+GRAPHQL_ENDPOINT = TBD
+```
+
+Use the provider’s indexing-status mechanism (for example, its indexed block and latest chain block) to check:
+
+- latest indexed block / indexing status;
+- names by owner, using the final `Domain`/account relationship;
+- a name by label, namehash, or token ID, depending on the final schema;
+- registration events (`Registration` or the final event entity);
+- renewal events (`Renewal` or the final event entity);
+- TLD breakdown for `arc` and `circle` names;
+- DiscountRegistry root state events: `DiscountRootUpdated`, `DiscountRootFrozen`, and active-state changes;
+- consumed discount events (`DiscountUsed`);
+- holder count or owner concentration summary, if supported by the final schema.
+
+Example placeholder shape (field names must be confirmed against the final schema):
+
+```graphql
+query NamesByOwner($owner: Bytes!) {
+  domains(where: { owner: $owner }, first: 25, orderBy: createdAt, orderDirection: desc) {
+    id
+    name
+    expiry
+    owner { id }
+  }
+}
+```
+
+Do not publish this placeholder as a production query contract until generated types, schema fields, and provider behavior have been validated.
+
+## H. Frontend dependency
+
+- The frontend mainnet switch must be a separate, reviewed PR.
+- Mainnet frontend configuration must never use the testnet subgraph endpoint.
+- Discount claim UX must remain hidden until proof delivery and the DiscountRegistry root lifecycle are independently ready and verified.
+- The frontend must handle indexer lag, unavailable queries, partial results, and provider failure gracefully.
+- Any direct RPC fallback must be read-only and must not expose secrets, private keys, wallet credentials, or API keys.
+- A frontend cutover must record the final chain configuration, contract addresses, GraphQL endpoint, fallback behavior, and rollback owner.
+
+## I. Monitoring and rollback
+
+The selected indexer operation must define:
+
+- sync lag monitoring against the latest mainnet block;
+- failed-handler and indexing-error monitoring;
+- GraphQL query error and latency monitoring;
+- provider outage detection and a read-only provider fallback;
+- an incident owner and escalation path;
+- rollback to maintenance or testnet messaging if the mainnet endpoint fails before public launch;
+- a rule that discount activation does not proceed while indexer readiness is incomplete.
+
+Rollback of the frontend endpoint is a configuration/release action, not an on-chain rollback. Indexed data must be re-synced or repaired through the selected provider’s reviewed operational procedure; no write operation belongs in this readiness plan.
+
+## J. Remaining blockers
+
+- Mainnet contract addresses: `TBD`.
+- Per-contract deployment blocks and block hashes: `TBD`.
+- Indexer provider/deployment target: `TBD`.
+- Mainnet subgraph endpoint: `TBD`.
+- Frontend GraphQL endpoint: `TBD`.
+- Sync health endpoint or monitoring method: `TBD`.
+- Deploy-grade RPC approval is unresolved.
+- Blockscout verification path is unresolved.
+- Frontend mainnet cutover is unresolved and must be separate.
+- Proof delivery integration remains unresolved if discount UX is in scope.
+- DiscountRegistry event/schema/handler coverage must be added and reviewed.
+- Final launch review is required after the evidence above is complete.
+
+## K. Non-goals
+
+- This document does not deploy contracts.
+- This document does not deploy or publish a subgraph.
+- This document does not create a mainnet endpoint.
+- This document does not switch the frontend to mainnet.
+- This document does not activate a discount.
+- This document does not approve mainnet launch.
+- This document does not submit transactions, sign anything, call write functions, modify prices or roots, or create/operate launch administration infrastructure.

--- a/docs/mainnet/SECURITY_CHECKLIST.md
+++ b/docs/mainnet/SECURITY_CHECKLIST.md
@@ -2,6 +2,8 @@
 
 Infrastructure acceptance evidence: [`DEPLOY_INFRA_READINESS.md`](./DEPLOY_INFRA_READINESS.md).
 
+Indexer/subgraph readiness evidence: [`INDEXER_SUBGRAPH_PLAN.md`](./INDEXER_SUBGRAPH_PLAN.md).
+
 - [ ] Confirm every ownership, admin, upgrade, pause, treasury, and deployer-revocation item in [`ADMIN_OWNERSHIP_PLAN.md`](./ADMIN_OWNERSHIP_PLAN.md).
 - [ ] Execute and verify the separately reviewed future ceremony in [`HANDOFF_CEREMONY_PLAN.md`](./HANDOFF_CEREMONY_PLAN.md) before launch.
 - [ ] Confirm standard oracle reads are 100/50/25/15/5 USDC in p1..p5 order.


### PR DESCRIPTION
This PR adds the ArcNS mainnet indexer / subgraph readiness plan for Aşama 5D.

Included:
- Adds docs/mainnet/INDEXER_SUBGRAPH_PLAN.md.
- Documents required mainnet indexer inputs.
- Keeps all unknown mainnet addresses, deployment blocks, endpoints, and monitoring values as TBD.
- Documents current testnet-oriented indexer/subgraph findings as historical reference only.
- Documents required mainnet data sources and event coverage.
- Records the current DiscountRegistry event coverage gap.
- Adds mainnet subgraph deployment sequence, start-block policy, readiness gates, smoke-query checklist, frontend dependency notes, and monitoring/rollback expectations.
- Cross-links the plan from the deployment runbook, security checklist, focused security review, and deploy infrastructure readiness docs.

Not approved:
- Mainnet indexer is not ready.
- Frontend mainnet cutover is not ready.
- Mainnet deployment is not approved.

Not included:
- No contract deployment.
- No subgraph deployment.
- No live on-chain write.
- No signing.
- No frontend mainnet switch.
- No deployment artifact change.
- No env, private key, API key, or secret changes.

Validation:
- Documentation-only diff.
- git diff --check passed.
- Restricted terminology scan passed.
- No Hardhat tests were required because only documentation changed.

Remaining blockers:
- Mainnet contract addresses and deployment blocks.
- Deploy-grade RPC.
- Blockscout verification path.
- Mainnet subgraph deployment and sync evidence.
- DiscountRegistry event/schema/handler coverage.
- Proof delivery integration.
- Frontend mainnet/discount cutover.
- Final launch review.