### PR TITLE
feat: add DiscountRegistry indexer coverage

### DIFF
--- a/docs/mainnet/FOCUSED_SECURITY_REVIEW.md
+++ b/docs/mainnet/FOCUSED_SECURITY_REVIEW.md
@@ -8,7 +8,7 @@ The follow-on mainnet indexer/subgraph readiness plan is tracked in [`INDEXER_SU
 
 The follow-on frontend mainnet/discount cutover plan is tracked in [`FRONTEND_CUTOVER_PLAN.md`](./FRONTEND_CUTOVER_PLAN.md).
 
-Remediation status: FSR-02 and FSR-06 are addressed by the Aşama 5A tooling guards. FSR-01 is partially addressed by a fail-closed read-only handoff assertion; final Safe/Timelock creation, handoff execution, and verification remain launch actions and blockers.
+Remediation status: FSR-02 and FSR-06 are addressed by the Aşama 5A tooling guards. FSR-01 is partially addressed by a fail-closed read-only handoff assertion. FSR-04 is partially addressed by Aşama 6A reusable DiscountRegistry ABI/schema/mapping coverage; final address/start-block wiring, deployment, sync, and health verification remain launch actions and blockers.
 
 This is an **internal focused review**, **not an external audit**. Mainnet deployment remains blocked until the blockers listed below are resolved and independently rechecked. No deployment, Arc on-chain write, signing, ownership transfer, role change, price update, Merkle-root update, campaign activation, production frontend switch, staging, commit, or push was performed by this review.
 
@@ -67,14 +67,14 @@ Deployment remains blocked by incomplete launch administration and infrastructur
 - **Docs-only fix sufficient:** No; infrastructure validation is required.
 - **Blocks Aşama 6:** Yes.
 
-### FSR-04 — Mainnet indexer/subgraph plan is unresolved
+### FSR-04 — Mainnet indexer/subgraph deployment remains unresolved
 
 - **Severity:** BLOCKER
 - **Affected:** `indexer/subgraph.yaml`, root `subgraph.yaml`, `bens-subgraph/subgraph.yaml`, frontend subgraph configuration, `docs/mainnet/ADMIN_OWNERSHIP_PLAN.md`
-- **Description:** Existing manifests/configuration are testnet-oriented and there is no finalized mainnet indexing deployment, start block, deployed-address manifest, health/readiness gate, or rollback/fallback plan.
+- **Description:** Existing concrete data sources/configuration remain testnet-oriented. Aşama 6A added DiscountRegistry ABI, schema entities, typed handlers, and a dormant template, but there is no known version-controlled DiscountRegistry deployment address/start block, finalized mainnet indexing deployment, deployed-address manifest, health/readiness gate, or rollback/fallback plan.
 - **Impact:** Names may register on-chain while portfolio, search, resolution, or availability-related indexed views remain stale or unavailable.
-- **Recommended fix:** Prepare a separate reviewed mainnet indexer change with final addresses and deployment block, validate schema/event coverage, deploy and sync it, and define frontend health/readiness checks before cutover.
-- **Code change required:** Yes.
+- **Recommended fix:** After deployment values exist, add a separately reviewed concrete data source with the final address and exact deployment block, revalidate all schema/event coverage, deploy and sync the mainnet subgraph, and define frontend health/readiness checks before cutover.
+- **Code change required:** Yes; reusable event coverage is implemented, while concrete deployment wiring remains `TBD`.
 - **Docs-only fix sufficient:** No.
 - **Blocks Aşama 6:** Yes.
 
@@ -201,3 +201,9 @@ Validation caveat: `test/v3/Integration.test.js` contains a smoke test that invo
 - Production frontend: not switched.
 - Git staging/commit/push: not performed.
 - Unrelated private planning materials: not accessed, modified, or included.
+
+## Aşama 6A indexer coverage update
+
+DiscountRegistry code-preparation coverage now includes all actual lifecycle events—`DiscountRootUpdated`, `DiscountRootFrozen`, `DiscountActiveUpdated`, `DiscountControllerAuthorizationUpdated`, and `DiscountUsed`—plus inherited `OwnershipTransferred`. Historical event entities use deterministic transaction-hash/log-index IDs, while current registry, owner, and controller authorization state are maintained separately. `snapshotBlock` is obtained from the immutable contract getter because it is not emitted by these events.
+
+No concrete DiscountRegistry address or start block was available in version-controlled deployment artifacts. The manifest therefore contains only a dormant template, not an active data source, and no value was invented. This update does not deploy or sync a subgraph, does not establish a mainnet endpoint, does not make the frontend ready, and does not close FSR-04.

--- a/docs/mainnet/INDEXER_SUBGRAPH_PLAN.md
+++ b/docs/mainnet/INDEXER_SUBGRAPH_PLAN.md
@@ -55,12 +55,23 @@ The current `indexer/` package is a testnet-oriented Graph Protocol project. Its
 | `.arc` / `.circle` registrars/NFTs | ERC-721 `Transfer` | `indexer/src/registrar.ts` handles ownership transfers and skips mints | Rebind both registrar sources; confirm token ID/labelhash behavior. |
 | Resolver | `AddrChanged`, `NameChanged` | `indexer/src/resolver.ts` handles address and name updates | Include if frontend resolution/reverse data depends on indexed state. |
 | Reverse registrar | `ReverseClaimed` | `indexer/src/reverseRegistrar.ts` handles reverse claims | Include if frontend reverse records depend on indexed state. |
-| DiscountRegistry | `DiscountRootUpdated`, `DiscountRootFrozen`, `DiscountActiveUpdated`, `DiscountControllerAuthorizationUpdated`, `DiscountUsed` | No DiscountRegistry data source, schema entities, or mapping handlers are present in the current indexer reference | **Coverage gap.** Add and review exact ABI/schema/handlers after final contract ABI is available; do not treat the current indexer as discount readiness. |
+| DiscountRegistry | `DiscountRootUpdated`, `DiscountRootFrozen`, `DiscountActiveUpdated`, `DiscountControllerAuthorizationUpdated`, `DiscountUsed`, inherited `OwnershipTransferred` | ABI, schema entities, typed handlers, and dormant template are implemented | Add a reviewed concrete data source only after the final address and exact start block are available; preparation alone is not deployment readiness. |
 | Ownership/admin sources | Contract-specific ownership and role events, if present | Not currently a dedicated source | Add only where useful for operational monitoring and only after confirming exact ABI event names. |
 
 The final event inventory must be generated from the verified mainnet ABIs. If a needed event does not exist on the deployed contract, record it as a gap and define a direct-read or alternate monitoring path rather than inventing an event or handler.
 
-The current schema supports domains, accounts, registrations, renewals, domain events, resolver records, reverse records, and labelhash lookup. Before deployment, verify that the schema supports the required counts and discount lifecycle queries. In particular, DiscountRegistry entities/events are not yet represented by the current reference schema.
+The current schema supports domains, accounts, registrations, renewals, domain events, resolver records, reverse records, labelhash lookup, DiscountRegistry current state, per-controller authorization state, and immutable DiscountRegistry event history. Before deployment, verify that the schema supports all required production counts and lifecycle queries against a concretely wired and synced data source.
+
+### Aşama 6A preparation status
+
+The reusable DiscountRegistry preparation is implemented in `indexer/`:
+
+- `abis/ArcNSEarlyAdopterDiscountRegistry.json` is derived from the compiled contract artifact;
+- `schema.graphql` contains current state, current controller authorization, and immutable history entities;
+- `src/discountRegistry.ts` handles all five DiscountRegistry lifecycle events plus inherited `OwnershipTransferred`, using transaction-hash/log-index IDs; and
+- `subgraph.yaml` contains a dormant template so codegen/build validate the ABI and handlers without inventing an address.
+
+The dormant template is not instantiated by any mapping and therefore indexes nothing. Concrete testnet/mainnet address and start-block wiring remains `TBD`.
 
 ## D. Mainnet subgraph deployment sequence (dry run)
 
@@ -174,7 +185,7 @@ Rollback of the frontend endpoint is a configuration/release action, not an on-c
 - Blockscout verification path is unresolved.
 - Frontend mainnet cutover is unresolved and must be separate.
 - Proof delivery integration remains unresolved if discount UX is in scope.
-- DiscountRegistry event/schema/handler coverage must be added and reviewed.
+- Concrete DiscountRegistry data-source address/start-block wiring remains `TBD`; reusable event/schema/handler coverage is implemented.
 - Final launch review is required after the evidence above is complete.
 
 ## K. Non-goals

--- a/docs/mainnet/SECURITY_CHECKLIST.md
+++ b/docs/mainnet/SECURITY_CHECKLIST.md
@@ -21,7 +21,10 @@ Frontend mainnet/discount cutover readiness evidence: [`FRONTEND_CUTOVER_PLAN.md
 - [ ] Confirm deployment left the discount root unset, unfrozen, and inactive; set, freeze, and activation are separate reviewed operations.
 - [ ] Run the read-only `scripts/mainnet/assert-admin-handoff.js` and require its PASS result before public launch.
 - [ ] Confirm no production frontend switch occurs before deployed addresses and proofs are available.
+- [x] Confirm reusable DiscountRegistry ABI/schema/event-handler coverage exists and passes indexer codegen/build.
+- [ ] Replace the dormant DiscountRegistry template with reviewed concrete data-source wiring after the final address and exact start block are available.
+- [ ] Deploy, fully sync, and health-check the reviewed mainnet subgraph before frontend cutover.
 
-Deploy-grade RPC selection, Blockscout verification, mainnet indexer/subgraph deployment, and frontend cutover remain unresolved launch blockers. This checklist is not mainnet deployment approval.
+Deploy-grade RPC selection, Blockscout verification, final DiscountRegistry address/start-block wiring, mainnet indexer/subgraph deployment and sync, and frontend cutover remain unresolved launch blockers. The implemented handler/schema preparation is not evidence of a deployed subgraph or frontend readiness. This checklist is not mainnet deployment approval.
 
 No deploy/push/on-chain action was performed in this phase.

--- a/indexer/abis/ArcNSEarlyAdopterDiscountRegistry.json
+++ b/indexer/abis/ArcNSEarlyAdopterDiscountRegistry.json
@@ -1,0 +1,410 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "campaignId_",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "snapshotBlock_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "owner_",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "DiscountAlreadyUsed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DiscountInactive",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "EmptyMerkleRoot",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidAccount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidProof",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableInvalidOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableUnauthorizedAccount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "RootAlreadyFrozen",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "RootNotFrozen",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "controller",
+        "type": "address"
+      }
+    ],
+    "name": "UnauthorizedController",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "active",
+        "type": "bool"
+      }
+    ],
+    "name": "DiscountActiveUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "controller",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "authorized",
+        "type": "bool"
+      }
+    ],
+    "name": "DiscountControllerAuthorizationUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "root",
+        "type": "bytes32"
+      }
+    ],
+    "name": "DiscountRootFrozen",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "oldRoot",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "newRoot",
+        "type": "bytes32"
+      }
+    ],
+    "name": "DiscountRootUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "controller",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "campaignId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "DiscountUsed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "authorizedControllers",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "campaignId",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "proof",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "consume",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "discountActive",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "freezeRoot",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "merkleRoot",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "rootFrozen",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "controller",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "authorized",
+        "type": "bool"
+      }
+    ],
+    "name": "setControllerAuthorization",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "active",
+        "type": "bool"
+      }
+    ],
+    "name": "setDiscountActive",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "newRoot",
+        "type": "bytes32"
+      }
+    ],
+    "name": "setMerkleRoot",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "snapshotBlock",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "used",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/indexer/schema.graphql
+++ b/indexer/schema.graphql
@@ -114,3 +114,102 @@ type LabelhashIndex @entity(immutable: true) {
   id: ID!          # "{tld}-{labelhashHex}" e.g. "arc-0x1234..."
   domainId: String! # namehash hex — the Domain entity id
 }
+
+# ─── DiscountRegistry ─────────────────────────────────────────────────────────
+# Mutable current state, keyed by the lowercase DiscountRegistry address.
+# campaignId and snapshotBlock are constructor immutables read from the contract
+# because they are not emitted by every lifecycle event.
+
+type DiscountRegistryState @entity(immutable: false) {
+  id: ID!                        # lowercase DiscountRegistry address
+  contractAddress: Bytes!
+  owner: Bytes
+  campaignId: Bytes
+  snapshotBlock: BigInt
+  merkleRoot: Bytes!
+  rootFrozen: Boolean!
+  discountActive: Boolean!
+  blockNumber: BigInt!
+  logIndex: BigInt!
+  timestamp: BigInt!
+  transactionHash: Bytes!
+}
+
+# Mutable current authorization state for one controller on one registry.
+
+type DiscountController @entity(immutable: false) {
+  id: ID!                        # "{registryAddress}-{controllerAddress}"
+  registry: DiscountRegistryState!
+  contractAddress: Bytes!
+  controller: Bytes!
+  authorized: Boolean!
+  blockNumber: BigInt!
+  logIndex: BigInt!
+  timestamp: BigInt!
+  transactionHash: Bytes!
+}
+
+type DiscountRootUpdate @entity(immutable: true) {
+  id: ID!                        # txHash-logIndex
+  contractAddress: Bytes!
+  oldRoot: Bytes!
+  newRoot: Bytes!
+  transactionHash: Bytes!
+  logIndex: BigInt!
+  blockNumber: BigInt!
+  timestamp: BigInt!
+}
+
+type DiscountRootFrozen @entity(immutable: true) {
+  id: ID!                        # txHash-logIndex
+  contractAddress: Bytes!
+  root: Bytes!
+  transactionHash: Bytes!
+  logIndex: BigInt!
+  blockNumber: BigInt!
+  timestamp: BigInt!
+}
+
+type DiscountActivationChange @entity(immutable: true) {
+  id: ID!                        # txHash-logIndex
+  contractAddress: Bytes!
+  active: Boolean!
+  transactionHash: Bytes!
+  logIndex: BigInt!
+  blockNumber: BigInt!
+  timestamp: BigInt!
+}
+
+type DiscountControllerAuthorization @entity(immutable: true) {
+  id: ID!                        # txHash-logIndex
+  contractAddress: Bytes!
+  controller: Bytes!
+  authorized: Boolean!
+  transactionHash: Bytes!
+  logIndex: BigInt!
+  blockNumber: BigInt!
+  timestamp: BigInt!
+}
+
+type DiscountConsumed @entity(immutable: true) {
+  id: ID!                        # txHash-logIndex
+  contractAddress: Bytes!
+  account: Bytes!
+  controller: Bytes!
+  campaignId: Bytes!
+  transactionHash: Bytes!
+  logIndex: BigInt!
+  blockNumber: BigInt!
+  timestamp: BigInt!
+}
+
+type DiscountRegistryOwnershipTransfer @entity(immutable: true) {
+  id: ID!                        # txHash-logIndex
+  contractAddress: Bytes!
+  previousOwner: Bytes!
+  newOwner: Bytes!
+  transactionHash: Bytes!
+  logIndex: BigInt!
+  blockNumber: BigInt!
+  timestamp: BigInt!
+}

--- a/indexer/src/discountRegistry.ts
+++ b/indexer/src/discountRegistry.ts
@@ -1,0 +1,224 @@
+import { Address, BigInt, Bytes } from "@graphprotocol/graph-ts";
+import {
+  ArcNSEarlyAdopterDiscountRegistry,
+  DiscountActiveUpdated as DiscountActiveUpdatedEvent,
+  DiscountControllerAuthorizationUpdated as DiscountControllerAuthorizationUpdatedEvent,
+  DiscountRootFrozen as DiscountRootFrozenEvent,
+  DiscountRootUpdated as DiscountRootUpdatedEvent,
+  DiscountUsed as DiscountUsedEvent,
+  OwnershipTransferred as OwnershipTransferredEvent,
+} from "../generated/templates/DiscountRegistry/ArcNSEarlyAdopterDiscountRegistry";
+import {
+  DiscountActivationChange,
+  DiscountConsumed,
+  DiscountController,
+  DiscountControllerAuthorization,
+  DiscountRegistryState,
+  DiscountRegistryOwnershipTransfer,
+  DiscountRootFrozen,
+  DiscountRootUpdate,
+} from "../generated/schema";
+
+const ZERO_ROOT = "0x0000000000000000000000000000000000000000000000000000000000000000";
+
+function eventId(transactionHash: Bytes, logIndex: string): string {
+  return transactionHash.toHexString() + "-" + logIndex;
+}
+
+function registryId(address: Address): string {
+  return address.toHexString().toLowerCase();
+}
+
+function loadOrCreateState(
+  address: Address,
+  transactionHash: Bytes,
+  blockNumber: BigInt,
+  logIndex: BigInt,
+  timestamp: BigInt
+): DiscountRegistryState {
+  let id = registryId(address);
+  let state = DiscountRegistryState.load(id);
+
+  if (!state) {
+    state = new DiscountRegistryState(id);
+    state.contractAddress = address;
+    state.merkleRoot = Bytes.fromHexString(ZERO_ROOT);
+    state.rootFrozen = false;
+    state.discountActive = false;
+
+    let registry = ArcNSEarlyAdopterDiscountRegistry.bind(address);
+    let campaignIdResult = registry.try_campaignId();
+    if (!campaignIdResult.reverted) {
+      state.campaignId = campaignIdResult.value;
+    }
+    let snapshotBlockResult = registry.try_snapshotBlock();
+    if (!snapshotBlockResult.reverted) {
+      state.snapshotBlock = snapshotBlockResult.value;
+    }
+    let ownerResult = registry.try_owner();
+    if (!ownerResult.reverted) {
+      state.owner = ownerResult.value;
+    }
+  }
+
+  state.blockNumber = blockNumber;
+  state.logIndex = logIndex;
+  state.timestamp = timestamp;
+  state.transactionHash = transactionHash;
+  return state;
+}
+
+export function handleDiscountRootUpdated(event: DiscountRootUpdatedEvent): void {
+  let id = eventId(event.transaction.hash, event.logIndex.toString());
+  let update = new DiscountRootUpdate(id);
+  update.contractAddress = event.address;
+  update.oldRoot = event.params.oldRoot;
+  update.newRoot = event.params.newRoot;
+  update.transactionHash = event.transaction.hash;
+  update.logIndex = event.logIndex;
+  update.blockNumber = event.block.number;
+  update.timestamp = event.block.timestamp;
+  update.save();
+
+  let state = loadOrCreateState(
+    event.address,
+    event.transaction.hash,
+    event.block.number,
+    event.logIndex,
+    event.block.timestamp
+  );
+  state.merkleRoot = event.params.newRoot;
+  state.save();
+}
+
+export function handleDiscountRootFrozen(event: DiscountRootFrozenEvent): void {
+  let id = eventId(event.transaction.hash, event.logIndex.toString());
+  let frozen = new DiscountRootFrozen(id);
+  frozen.contractAddress = event.address;
+  frozen.root = event.params.root;
+  frozen.transactionHash = event.transaction.hash;
+  frozen.logIndex = event.logIndex;
+  frozen.blockNumber = event.block.number;
+  frozen.timestamp = event.block.timestamp;
+  frozen.save();
+
+  let state = loadOrCreateState(
+    event.address,
+    event.transaction.hash,
+    event.block.number,
+    event.logIndex,
+    event.block.timestamp
+  );
+  state.merkleRoot = event.params.root;
+  state.rootFrozen = true;
+  state.save();
+}
+
+export function handleDiscountActiveUpdated(event: DiscountActiveUpdatedEvent): void {
+  let id = eventId(event.transaction.hash, event.logIndex.toString());
+  let change = new DiscountActivationChange(id);
+  change.contractAddress = event.address;
+  change.active = event.params.active;
+  change.transactionHash = event.transaction.hash;
+  change.logIndex = event.logIndex;
+  change.blockNumber = event.block.number;
+  change.timestamp = event.block.timestamp;
+  change.save();
+
+  let state = loadOrCreateState(
+    event.address,
+    event.transaction.hash,
+    event.block.number,
+    event.logIndex,
+    event.block.timestamp
+  );
+  state.discountActive = event.params.active;
+  state.save();
+}
+
+export function handleDiscountControllerAuthorizationUpdated(
+  event: DiscountControllerAuthorizationUpdatedEvent
+): void {
+  let id = eventId(event.transaction.hash, event.logIndex.toString());
+  let authorization = new DiscountControllerAuthorization(id);
+  authorization.contractAddress = event.address;
+  authorization.controller = event.params.controller;
+  authorization.authorized = event.params.authorized;
+  authorization.transactionHash = event.transaction.hash;
+  authorization.logIndex = event.logIndex;
+  authorization.blockNumber = event.block.number;
+  authorization.timestamp = event.block.timestamp;
+  authorization.save();
+
+  let state = loadOrCreateState(
+    event.address,
+    event.transaction.hash,
+    event.block.number,
+    event.logIndex,
+    event.block.timestamp
+  );
+  state.save();
+
+  let controllerId =
+    registryId(event.address) + "-" + event.params.controller.toHexString().toLowerCase();
+  let controller = DiscountController.load(controllerId);
+  if (!controller) {
+    controller = new DiscountController(controllerId);
+    controller.registry = state.id;
+    controller.contractAddress = event.address;
+    controller.controller = event.params.controller;
+  }
+  controller.authorized = event.params.authorized;
+  controller.transactionHash = event.transaction.hash;
+  controller.logIndex = event.logIndex;
+  controller.blockNumber = event.block.number;
+  controller.timestamp = event.block.timestamp;
+  controller.save();
+}
+
+export function handleDiscountUsed(event: DiscountUsedEvent): void {
+  let id = eventId(event.transaction.hash, event.logIndex.toString());
+  let consumed = new DiscountConsumed(id);
+  consumed.contractAddress = event.address;
+  consumed.account = event.params.account;
+  consumed.controller = event.params.controller;
+  consumed.campaignId = event.params.campaignId;
+  consumed.transactionHash = event.transaction.hash;
+  consumed.logIndex = event.logIndex;
+  consumed.blockNumber = event.block.number;
+  consumed.timestamp = event.block.timestamp;
+  consumed.save();
+
+  let state = loadOrCreateState(
+    event.address,
+    event.transaction.hash,
+    event.block.number,
+    event.logIndex,
+    event.block.timestamp
+  );
+  state.campaignId = event.params.campaignId;
+  state.save();
+}
+
+export function handleOwnershipTransferred(event: OwnershipTransferredEvent): void {
+  let id = eventId(event.transaction.hash, event.logIndex.toString());
+  let transfer = new DiscountRegistryOwnershipTransfer(id);
+  transfer.contractAddress = event.address;
+  transfer.previousOwner = event.params.previousOwner;
+  transfer.newOwner = event.params.newOwner;
+  transfer.transactionHash = event.transaction.hash;
+  transfer.logIndex = event.logIndex;
+  transfer.blockNumber = event.block.number;
+  transfer.timestamp = event.block.timestamp;
+  transfer.save();
+
+  let state = loadOrCreateState(
+    event.address,
+    event.transaction.hash,
+    event.block.number,
+    event.logIndex,
+    event.block.timestamp
+  );
+  state.owner = event.params.newOwner;
+  state.save();
+}

--- a/indexer/subgraph.yaml
+++ b/indexer/subgraph.yaml
@@ -187,3 +187,44 @@ dataSources:
         - event: ReverseClaimed(indexed address,indexed bytes32)
           handler: handleReverseClaimed
       file: ./src/reverseRegistrar.ts
+
+# DiscountRegistry has no version-controlled testnet deployment address/start
+# block. This dormant template validates its ABI, schema, and handlers without
+# inventing an address or indexing anything. A future reviewed manifest must
+# wire a concrete data source with the final address and exact start block.
+templates:
+  - kind: ethereum
+    name: DiscountRegistry
+    network: arc-testnet
+    source:
+      abi: ArcNSEarlyAdopterDiscountRegistry
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.9
+      language: wasm/assemblyscript
+      entities:
+        - DiscountRegistryState
+        - DiscountController
+        - DiscountRootUpdate
+        - DiscountRootFrozen
+        - DiscountActivationChange
+        - DiscountControllerAuthorization
+        - DiscountConsumed
+        - DiscountRegistryOwnershipTransfer
+      abis:
+        - name: ArcNSEarlyAdopterDiscountRegistry
+          file: ./abis/ArcNSEarlyAdopterDiscountRegistry.json
+      eventHandlers:
+        - event: DiscountRootUpdated(indexed bytes32,indexed bytes32)
+          handler: handleDiscountRootUpdated
+        - event: DiscountRootFrozen(indexed bytes32)
+          handler: handleDiscountRootFrozen
+        - event: DiscountActiveUpdated(bool)
+          handler: handleDiscountActiveUpdated
+        - event: DiscountControllerAuthorizationUpdated(indexed address,bool)
+          handler: handleDiscountControllerAuthorizationUpdated
+        - event: DiscountUsed(indexed address,indexed address,indexed bytes32)
+          handler: handleDiscountUsed
+        - event: OwnershipTransferred(indexed address,indexed address)
+          handler: handleOwnershipTransferred
+      file: ./src/discountRegistry.ts


### PR DESCRIPTION
This PR adds reusable DiscountRegistry coverage to the ArcNS indexer/subgraph preparation.

Included:
- Adds DiscountRegistry ABI copied from the compiled contract artifact.
- Adds DiscountRegistry schema entities.
- Adds DiscountRegistry event mappings.
- Adds a dormant DiscountRegistry template to subgraph.yaml.
- Covers:
  - DiscountRootUpdated
  - DiscountRootFrozen
  - DiscountActiveUpdated
  - DiscountControllerAuthorizationUpdated
  - DiscountUsed
  - OwnershipTransferred
- Updates mainnet readiness docs to reflect that handler/schema coverage exists but concrete mainnet data-source wiring remains TBD.

Important:
- No fake mainnet address was added.
- No final mainnet DiscountRegistry address or start block was invented.
- The DiscountRegistry template is dormant and indexes nothing until a concrete data source is wired with final deployment data.
- Mainnet indexer is still not ready until final addresses, start blocks, deployment, sync, endpoint, and smoke-query evidence exist.

Not included:
- No contract deployment.
- No subgraph deployment or publication.
- No live on-chain write.
- No signing.
- No price/root/freeze/activation operation.
- No frontend mainnet switch.
- No environment, secret, API key, or deployment artifact change.

Validation:
- git diff --check passed.
- Restricted terminology scan passed.
- DiscountRegistry ABI matched the compiled artifact.
- npm --prefix indexer run codegen passed.
- npm --prefix indexer run build passed.

Remaining blockers:
- Final mainnet DiscountRegistry address.
- Exact mainnet start block and block hash.
- Concrete mainnet data-source wiring.
- Approved indexer RPC/provider/deployment target.
- Mainnet subgraph deployment and sync.
- Mainnet GraphQL endpoint and health evidence.
- Frontend mainnet cutover.