### PR TITLE
feat: add inactive frontend discount proof helper

### DIFF
--- a/docs/mainnet/FRONTEND_CUTOVER_PLAN.md
+++ b/docs/mainnet/FRONTEND_CUTOVER_PLAN.md
@@ -10,6 +10,8 @@ Mainnet contract addresses, the mainnet subgraph endpoint, proof delivery, and V
 
 Proof artifact preparation is tracked separately in [`PROOF_DELIVERY_PLAN.md`](./PROOF_DELIVERY_PLAN.md).
 
+An inactive typed helper now validates and looks up the bundled static proof artifact at `frontend/src/lib/discountProofs.ts`. It is not connected to components, hooks, active registration, or `registerWithDiscount`; it does not use RPC or establish claim availability. Discount UI and the production network selection remain unchanged.
+
 ## B. Required frontend inputs
 
 | Input | Required value | Source | Status | Notes |
@@ -48,7 +50,7 @@ The following findings are based on the current repository inspection; they do n
 - **Contract address wiring:** `frontend/src/lib/contracts.ts` consumes testnet values exported by `frontend/src/lib/generated-contracts.ts`. `scripts/generate-frontend-config.js` currently targets the testnet deployment file. Mainnet addresses are absent and must not be inferred.
 - **Registration flow:** `frontend/src/hooks/useRegistration.ts` implements the active commit-reveal flow, including USDC approval and controller `register`; `frontend/src/hooks/useAvailability.ts` reads `available`, `rentPrice`, and expiry-related state directly from contracts.
 - **Renewal flow:** `frontend/src/hooks/useRenew.ts` performs direct ownership reads, USDC approval, and controller `renew`; it uses the normal quote and max-cost path.
-- **Discount UI/integration:** No active discount UI, `registerWithDiscount` call, proof lookup, or Merkle-proof handling was found under `frontend/src`. Discount UX is therefore absent/inactive rather than launch-ready.
+- **Discount UI/integration:** A static, read-only proof lookup helper and isolated tests now exist, but no active discount UI, `registerWithDiscount` call, hook integration, or component integration exists. The helper validates finalized artifact metadata and returns local lookup results only. Discount UX remains absent/inactive rather than launch-ready.
 - **Subgraph configuration:** `frontend/src/lib/graphql.ts` reads `NEXT_PUBLIC_SUBGRAPH_URL`, `NEXT_PUBLIC_SUBGRAPH_FALLBACK_URL`, and `NEXT_PUBLIC_GOLDSKY_SUBGRAPH_URL`. No final mainnet endpoint exists.
 - **Direct reads versus indexed reads:** Availability, quotes, allowance/balance, registration, and renewal rely on direct contract interactions. Portfolio, registration/renewal history, and resolution-oriented reads can use GraphQL, with null/empty failure behavior and RPC fallback in relevant call sites.
 - **Wallet/network handling:** `frontend/src/lib/wagmiConfig.ts` configures Wagmi connectors. `frontend/src/app/providers.tsx` shows a wrong-network banner, and registration/renewal hooks reject a wallet chain that differs from `DEPLOYED_CHAIN_ID`. A reviewed mainnet-preview-only switch prompt is not yet implemented.
@@ -101,6 +103,8 @@ Steps 11 and 20 are future release operations and are not performed by this plan
 | Premium/expired-name premium handling is explained | Quote UI/tests show discount applies only to base and any premium remains full; current lifecycle caveat is documented | `TBD` | Yes |
 | Indexer supports discount lifecycle/consumption events or fallback direct reads are defined | Synced query evidence or reviewed read-only fallback specification | `TBD` | Yes |
 | Activation has explicit approval | Recorded final launch approval after all prior gates | `TBD` | Yes |
+
+The inactive helper does not satisfy these runtime gates. Proof existence is not evidence that the on-chain root matches, the root is frozen, the campaign is active, the controller is authorized, or the wallet's claim is unused. A future reviewed UI must check those states through approved read paths before presenting a final discount action.
 
 ## F. Frontend smoke test checklist
 
@@ -167,6 +171,7 @@ Never activate the discount solely because the frontend appears ready. Frontend 
 - Final mainnet contract addresses are `TBD`.
 - Final mainnet subgraph endpoint is `TBD`.
 - Proof delivery is unresolved.
+- The static proof helper is inactive; final used-state/lifecycle gating and `registerWithDiscount` wiring are unresolved.
 - Deploy-grade RPC is unresolved.
 - Blockscout verification is unresolved.
 - Mainnet indexer/subgraph is not deployed or synchronized.

--- a/docs/mainnet/PROOF_DELIVERY_PLAN.md
+++ b/docs/mainnet/PROOF_DELIVERY_PLAN.md
@@ -31,21 +31,25 @@ Both commands are network-free, read-only, and require no signer or RPC.
 
 ## D. Frontend integration rules
 
+- A typed helper now exists at `frontend/src/lib/discountProofs.ts`, but it is intentionally inactive and is not imported by any active UI or registration flow.
+- The helper only fetches the bundled static artifact, validates its finalized metadata, normalizes an address, and performs a local proof lookup. It does not use RPC or call a contract.
 - Look up proofs using the lowercase connected wallet address.
 - A missing proof is an ineligible fallback; do not claim eligibility.
-- Proof existence alone does not mean the discount is active.
-- Check or safely handle already-used discount state before presenting the path.
+- Proof existence alone does not mean the discount is active, usable, or still unclaimed.
+- Before presenting any final discount action, a future reviewed integration must fail closed unless root equality, frozen state, activation state, controller authorization, and already-used state have been checked through approved read paths.
 - Enforce one-time use across both `.arc` and `.circle` namespaces.
 - Do not discount an expired-name premium, if a premium exists.
 - Keep discount UI hidden until activation approval.
 - Do not assume the root is frozen until read-back confirms it.
+- `registerWithDiscount` is not wired in this phase.
 
 ## E. Readiness gates
 
 - [x] Artifact generated and validated.
 - [x] 849 proofs present.
 - [x] Root matches finalized root.
-- [ ] Frontend integration PR created.
+- [x] Inactive static proof lookup helper and unit coverage prepared.
+- [ ] Active frontend discount integration reviewed and approved.
 - [ ] Preview smoke tests passed.
 - [ ] DiscountRegistry deployed.
 - [ ] Root set and frozen.
@@ -55,7 +59,7 @@ Both commands are network-free, read-only, and require no signer or RPC.
 
 ## F. Remaining blockers
 
-Final mainnet addresses are TBD; the artifact is not wired into active UI; discount UI is not enabled; the root is not set/frozen on mainnet; DiscountRegistry is not deployed on mainnet; frontend cutover is not implemented; the indexer/subgraph is not deployed/synced; and final launch review is required.
+Final mainnet addresses are TBD; the helper and artifact are not wired into active UI; `registerWithDiscount` is not wired; discount UI is not enabled; the root is not set/frozen on mainnet; DiscountRegistry is not deployed on mainnet; frontend cutover is not implemented; the indexer/subgraph is not deployed/synced; and final launch review is required. The helper is preparation only and does not mean the frontend discount UX is ready.
 
 ## G. Non-goals
 

--- a/docs/mainnet/SECURITY_CHECKLIST.md
+++ b/docs/mainnet/SECURITY_CHECKLIST.md
@@ -23,10 +23,13 @@ Proof delivery evidence: [`PROOF_DELIVERY_PLAN.md`](./PROOF_DELIVERY_PLAN.md).
 - [ ] Confirm deployment left the discount root unset, unfrozen, and inactive; set, freeze, and activation are separate reviewed operations.
 - [ ] Run the read-only `scripts/mainnet/assert-admin-handoff.js` and require its PASS result before public launch.
 - [ ] Confirm no production frontend switch occurs before deployed addresses and proofs are available.
+- [x] Confirm the inactive frontend helper performs only bundled static proof lookup, validates finalized metadata, and has no RPC, contract, or active UI integration.
+- [ ] Keep discount UI disabled and `registerWithDiscount` unwired until a separate reviewed integration passes every frontend cutover gate.
+- [ ] Before presenting a final discount action, confirm approved read paths verify root equality, frozen state, activation state, controller authorization, and already-used state; proof existence alone is insufficient.
 - [x] Confirm reusable DiscountRegistry ABI/schema/event-handler coverage exists and passes indexer codegen/build.
 - [ ] Replace the dormant DiscountRegistry template with reviewed concrete data-source wiring after the final address and exact start block are available.
 - [ ] Deploy, fully sync, and health-check the reviewed mainnet subgraph before frontend cutover.
 
-Deploy-grade RPC selection, Blockscout verification, final DiscountRegistry address/start-block wiring, mainnet indexer/subgraph deployment and sync, and frontend cutover remain unresolved launch blockers. The implemented handler/schema preparation is not evidence of a deployed subgraph or frontend readiness. This checklist is not mainnet deployment approval.
+Deploy-grade RPC selection, Blockscout verification, final DiscountRegistry address/start-block wiring, mainnet indexer/subgraph deployment and sync, active discount integration, and frontend cutover remain unresolved launch blockers. The implemented handler/schema preparation and inactive static proof helper are not evidence of a deployed subgraph, usable discount, or frontend readiness. The production frontend remains testnet-bound. This checklist is not mainnet deployment approval.
 
 No deploy/push/on-chain action was performed in this phase.

--- a/frontend/src/__tests__/discountProofs.test.ts
+++ b/frontend/src/__tests__/discountProofs.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import proofArtifact from "../../public/discount-proofs/arcns-v3-early-adopter-2026.json";
+import {
+  EARLY_ADOPTER_PROOF_ARTIFACT_PATH,
+  lookupEarlyAdopterProof,
+  lookupEarlyAdopterProofFromArtifact,
+} from "../lib/discountProofs";
+
+const ELIGIBLE_ADDRESS = "0x0000b9b20ddd33cd240e8d3b7afa02fa1cdaebcc";
+const INELIGIBLE_ADDRESS = "0x0000000000000000000000000000000000000001";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("lookupEarlyAdopterProofFromArtifact", () => {
+  it("returns the proof for a known eligible wallet", () => {
+    const result = lookupEarlyAdopterProofFromArtifact(ELIGIBLE_ADDRESS, proofArtifact);
+
+    expect(result.status).toBe("eligible");
+    if (result.status === "eligible") {
+      expect(result.proof).toEqual(proofArtifact.proofs[ELIGIBLE_ADDRESS]);
+      expect(result.metadata.eligibleWalletCount).toBe(849);
+    }
+  });
+
+  it("normalizes a mixed-case address before lookup", () => {
+    const mixedCaseAddress = "0x0000B9B20dDd33Cd240E8d3B7AfA02Fa1CdAeBcC";
+    const result = lookupEarlyAdopterProofFromArtifact(mixedCaseAddress, proofArtifact);
+
+    expect(result.status).toBe("eligible");
+    if (result.status === "eligible") {
+      expect(result.address).toBe(ELIGIBLE_ADDRESS);
+    }
+  });
+
+  it("returns a safe ineligible result when no proof exists", () => {
+    expect(lookupEarlyAdopterProofFromArtifact(INELIGIBLE_ADDRESS, proofArtifact)).toEqual({
+      status: "ineligible",
+      address: INELIGIBLE_ADDRESS,
+      reason: "missing-proof",
+    });
+  });
+
+  it("rejects an invalid address before reading artifact data", () => {
+    expect(lookupEarlyAdopterProofFromArtifact("not-an-address", null)).toMatchObject({
+      status: "invalid-address",
+    });
+  });
+
+  it("fails closed when finalized metadata does not match", () => {
+    const mismatchedArtifact = { ...proofArtifact, snapshotBlock: 1 };
+
+    expect(
+      lookupEarlyAdopterProofFromArtifact(ELIGIBLE_ADDRESS, mismatchedArtifact),
+    ).toEqual({ status: "unavailable", reason: "metadata-mismatch" });
+  });
+
+  it("fails closed when proof data is malformed", () => {
+    const malformedArtifact = {
+      ...proofArtifact,
+      proofs: { ...proofArtifact.proofs, [ELIGIBLE_ADDRESS]: ["0x1234"] },
+    };
+
+    expect(lookupEarlyAdopterProofFromArtifact(ELIGIBLE_ADDRESS, malformedArtifact)).toEqual({
+      status: "unavailable",
+      reason: "artifact-invalid",
+    });
+  });
+});
+
+describe("lookupEarlyAdopterProof", () => {
+  it("fetches only the bundled static proof artifact", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => proofArtifact,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(lookupEarlyAdopterProof(ELIGIBLE_ADDRESS)).resolves.toMatchObject({
+      status: "eligible",
+      address: ELIGIBLE_ADDRESS,
+    });
+    expect(fetchMock).toHaveBeenCalledWith(EARLY_ADOPTER_PROOF_ARTIFACT_PATH, {
+      method: "GET",
+      cache: "force-cache",
+      credentials: "same-origin",
+    });
+  });
+
+  it("returns unavailable when the artifact cannot be fetched", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+
+    await expect(lookupEarlyAdopterProof(ELIGIBLE_ADDRESS)).resolves.toEqual({
+      status: "unavailable",
+      reason: "artifact-fetch-failed",
+    });
+  });
+});

--- a/frontend/src/lib/discountProofs.ts
+++ b/frontend/src/lib/discountProofs.ts
@@ -1,0 +1,176 @@
+import { isAddress, type Address, type Hex } from "viem";
+
+/**
+ * Static artifact prepared for a future early-adopter discount experience.
+ *
+ * This module performs local proof lookup only. A matching proof does not show
+ * that a registry is deployed, its root is set or frozen, the campaign is
+ * active, or the wallet has not already used its claim.
+ */
+
+export const EARLY_ADOPTER_PROOF_ARTIFACT_PATH =
+  "/discount-proofs/arcns-v3-early-adopter-2026.json";
+
+export const EARLY_ADOPTER_PROOF_METADATA = {
+  campaignId: "ARCNS_TESTNET_V3_EARLY_ADOPTER_2026_V1",
+  campaignIdBytes32:
+    "0xae3c7462e46cc76b3e0349e7d211264ada95257da9d9d7a797abed70b7eb83e3",
+  snapshotBlock: 54933646,
+  snapshotBlockHash:
+    "0x0a450d7fb8055de409084ddb9942f31431aa017a3b3241c4eb8e2e655b8c024d",
+  merkleRoot:
+    "0xf18c50fa221162f76d0b88f21aa26e4211c5a77ee72d4dd58240a40406f38d9e",
+  eligibleWalletCount: 849,
+} as const;
+
+export type DiscountProofMetadata = typeof EARLY_ADOPTER_PROOF_METADATA;
+
+export type DiscountProofLookupResult =
+  | {
+      status: "eligible";
+      address: Address;
+      proof: Hex[];
+      metadata: DiscountProofMetadata;
+    }
+  | {
+      status: "ineligible";
+      address: Address;
+      reason: "missing-proof";
+    }
+  | {
+      status: "invalid-address";
+      reason: string;
+    }
+  | {
+      status: "unavailable";
+      reason: "artifact-fetch-failed" | "artifact-invalid" | "metadata-mismatch";
+    };
+
+type ProofArtifact = DiscountProofMetadata & {
+  version: 1;
+  proofs: Record<string, Hex[]>;
+};
+
+const BYTES32_PATTERN = /^0x[0-9a-fA-F]{64}$/;
+
+function normalizeAddress(address: string): Address | null {
+  if (typeof address !== "string") return null;
+
+  const trimmed = address.trim();
+  if (!isAddress(trimmed, { strict: false })) return null;
+
+  return trimmed.toLowerCase() as Address;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasExpectedMetadata(value: Record<string, unknown>): boolean {
+  return (
+    value.campaignId === EARLY_ADOPTER_PROOF_METADATA.campaignId &&
+    value.campaignIdBytes32 === EARLY_ADOPTER_PROOF_METADATA.campaignIdBytes32 &&
+    value.snapshotBlock === EARLY_ADOPTER_PROOF_METADATA.snapshotBlock &&
+    value.snapshotBlockHash === EARLY_ADOPTER_PROOF_METADATA.snapshotBlockHash &&
+    value.merkleRoot === EARLY_ADOPTER_PROOF_METADATA.merkleRoot &&
+    value.eligibleWalletCount === EARLY_ADOPTER_PROOF_METADATA.eligibleWalletCount
+  );
+}
+
+function parseArtifact(
+  value: unknown,
+): { artifact: ProofArtifact } | { error: "artifact-invalid" | "metadata-mismatch" } {
+  if (!isRecord(value)) return { error: "artifact-invalid" };
+  if (!hasExpectedMetadata(value)) return { error: "metadata-mismatch" };
+  if (value.version !== 1 || !isRecord(value.proofs)) {
+    return { error: "artifact-invalid" };
+  }
+
+  const entries = Object.entries(value.proofs);
+  if (entries.length !== EARLY_ADOPTER_PROOF_METADATA.eligibleWalletCount) {
+    return { error: "metadata-mismatch" };
+  }
+
+  for (const [address, proof] of entries) {
+    if (
+      address !== address.toLowerCase() ||
+      !isAddress(address, { strict: false }) ||
+      !Array.isArray(proof) ||
+      proof.length === 0 ||
+      !proof.every((item) => typeof item === "string" && BYTES32_PATTERN.test(item))
+    ) {
+      return { error: "artifact-invalid" };
+    }
+  }
+
+  return { artifact: value as ProofArtifact };
+}
+
+/**
+ * Pure lookup entry point for validation and unit tests.
+ * It does not perform network, RPC, wallet, or contract operations.
+ */
+export function lookupEarlyAdopterProofFromArtifact(
+  address: string,
+  artifactValue: unknown,
+): DiscountProofLookupResult {
+  const normalizedAddress = normalizeAddress(address);
+  if (!normalizedAddress) {
+    return {
+      status: "invalid-address",
+      reason: "Address must be a valid 0x-prefixed EVM address.",
+    };
+  }
+
+  const parsed = parseArtifact(artifactValue);
+  if ("error" in parsed) {
+    return { status: "unavailable", reason: parsed.error };
+  }
+
+  const proof = parsed.artifact.proofs[normalizedAddress];
+  if (!proof) {
+    return { status: "ineligible", address: normalizedAddress, reason: "missing-proof" };
+  }
+
+  return {
+    status: "eligible",
+    address: normalizedAddress,
+    proof: [...proof],
+    metadata: EARLY_ADOPTER_PROOF_METADATA,
+  };
+}
+
+/**
+ * Fetch the bundled static artifact and look up an address.
+ *
+ * This helper intentionally does not read chain state or determine whether a
+ * discount action is available. Future UI code must separately fail closed on
+ * root, freeze, activation, controller authorization, and already-used state.
+ */
+export async function lookupEarlyAdopterProof(
+  address: string,
+): Promise<DiscountProofLookupResult> {
+  const normalizedAddress = normalizeAddress(address);
+  if (!normalizedAddress) {
+    return {
+      status: "invalid-address",
+      reason: "Address must be a valid 0x-prefixed EVM address.",
+    };
+  }
+
+  try {
+    const response = await fetch(EARLY_ADOPTER_PROOF_ARTIFACT_PATH, {
+      method: "GET",
+      cache: "force-cache",
+      credentials: "same-origin",
+    });
+
+    if (!response.ok) {
+      return { status: "unavailable", reason: "artifact-fetch-failed" };
+    }
+
+    return lookupEarlyAdopterProofFromArtifact(normalizedAddress, await response.json());
+  } catch {
+    return { status: "unavailable", reason: "artifact-fetch-failed" };
+  }
+}


### PR DESCRIPTION
This PR adds an inactive frontend proof lookup helper for future early-adopter discount UX.

Included:
- Adds frontend/src/lib/discountProofs.ts.
- Adds focused tests for proof lookup behavior.
- Loads the static early-adopter proof artifact from:
  /discount-proofs/arcns-v3-early-adopter-2026.json
- Validates finalized proof metadata:
  - campaign ID
  - campaign bytes32
  - snapshot block
  - snapshot block hash
  - Merkle root
  - eligible wallet count
- Supports safe lookup results for eligible, ineligible, invalid-address, and unavailable states.
- Updates proof delivery, frontend cutover, and security docs.

Important:
- Discount UI is not enabled.
- registerWithDiscount is not wired.
- The helper performs no contract calls.
- The helper requires no RPC.
- The helper does not assume root is frozen or discount is active.
- Proof existence does not mean claim availability.
- Frontend remains testnet-bound.

Not included:
- No contract deployment.
- No frontend deployment.
- No live on-chain write.
- No signing.
- No root set/freeze/activation.
- No frontend mainnet switch.
- No discount UI activation.
- No final mainnet contract addresses.
- No final mainnet subgraph endpoint.
- No env, private key, API key, or secret changes.

Validation:
- Frontend proof helper tests passed.
- Frontend build passed.
- Proof artifact validator passed with 849 proofs.
- git diff --check passed.
- Restricted terminology scan passed.

Remaining blockers:
- Final mainnet contract addresses.
- DiscountRegistry deployment.
- Root set/freeze ceremony.
- Discount activation approval.
- Active frontend discount UI integration.
- Used-state direct-read or indexer fallback.
- Mainnet indexer/subgraph deployment and sync.
- Frontend mainnet cutover.
- Final launch review.