### PR TITLE
feat: add disabled frontend discount UX shell

### DIFF
--- a/docs/mainnet/FRONTEND_CUTOVER_PLAN.md
+++ b/docs/mainnet/FRONTEND_CUTOVER_PLAN.md
@@ -10,7 +10,7 @@ Mainnet contract addresses, the mainnet subgraph endpoint, proof delivery, and V
 
 Proof artifact preparation is tracked separately in [`PROOF_DELIVERY_PLAN.md`](./PROOF_DELIVERY_PLAN.md).
 
-An inactive typed helper now validates and looks up the bundled static proof artifact at `frontend/src/lib/discountProofs.ts`. It is not connected to components, hooks, active registration, or `registerWithDiscount`; it does not use RPC or establish claim availability. Discount UI and the production network selection remain unchanged.
+An inactive typed helper now validates and looks up the bundled static proof artifact at `frontend/src/lib/discountProofs.ts`. A separate `EarlyAdopterDiscountCard` UX shell exists only as an unmounted, disabled-by-default preview structure. Neither is connected to active registration, renewal, or `registerWithDiscount`; neither establishes claim availability. Discount UI and the production network selection remain unchanged.
 
 ## B. Required frontend inputs
 
@@ -71,6 +71,7 @@ This is a dry-run sequence only:
 8. Add the final mainnet subgraph endpoint.
 9. Add proof delivery integration.
 10. Keep discount UI inactive by default.
+    - The inactive shell may be reviewed only behind the explicit fail-closed flag; it must not expose a claim CTA.
 11. Deploy preview only.
 12. Run frontend smoke tests on preview.
 13. Verify the normal registration quote path.
@@ -104,7 +105,7 @@ Steps 11 and 20 are future release operations and are not performed by this plan
 | Indexer supports discount lifecycle/consumption events or fallback direct reads are defined | Synced query evidence or reviewed read-only fallback specification | `TBD` | Yes |
 | Activation has explicit approval | Recorded final launch approval after all prior gates | `TBD` | Yes |
 
-The inactive helper does not satisfy these runtime gates. Proof existence is not evidence that the on-chain root matches, the root is frozen, the campaign is active, the controller is authorized, or the wallet's claim is unused. A future reviewed UI must check those states through approved read paths before presenting a final discount action.
+The inactive helper and UX shell do not satisfy these runtime gates. Proof existence is not evidence that the on-chain root matches, the root is frozen, the campaign is active, the controller is authorized, or the wallet's claim is unused. A future reviewed UI must check those states through approved read paths before presenting a final discount action.
 
 ## F. Frontend smoke test checklist
 
@@ -146,7 +147,7 @@ The separate frontend PR must map final configuration to the repository's review
 - `NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID` = `TBD` under the approved project configuration;
 - mainnet contract-address source/config = `TBD` (prefer a reviewed generated public config rather than individually invented variables);
 - proof delivery endpoint or bundled artifact selector = `TBD`;
-- discount UI feature flag, default off = `TBD`;
+- `NEXT_PUBLIC_ENABLE_EARLY_ADOPTER_DISCOUNT_UI` = omitted or any value other than the exact string `true` until every activation gate passes;
 - mainnet registration enable/maintenance flag, fail closed = `TBD`.
 
 ### Production cutover

--- a/docs/mainnet/PROOF_DELIVERY_PLAN.md
+++ b/docs/mainnet/PROOF_DELIVERY_PLAN.md
@@ -42,6 +42,8 @@ Both commands are network-free, read-only, and require no signer or RPC.
 - Keep discount UI hidden until activation approval.
 - Do not assume the root is frozen until read-back confirms it.
 - `registerWithDiscount` is not wired in this phase.
+- An isolated `EarlyAdopterDiscountCard` UX shell now exists for explicitly reviewed preview use, but it is not mounted by the active app and the feature flag defaults to false. It performs no RPC or contract operation and exposes no claim or registration CTA.
+- The shell's proof-found state is informational only: proof existence does not imply claim availability. Production must keep the flag disabled until mainnet deployment, root set and freeze readback, discount activation approval, used-state readback or indexer support, preview smoke tests, and frontend cutover approval are complete.
 
 ## E. Readiness gates
 

--- a/docs/mainnet/SECURITY_CHECKLIST.md
+++ b/docs/mainnet/SECURITY_CHECKLIST.md
@@ -24,6 +24,7 @@ Proof delivery evidence: [`PROOF_DELIVERY_PLAN.md`](./PROOF_DELIVERY_PLAN.md).
 - [ ] Run the read-only `scripts/mainnet/assert-admin-handoff.js` and require its PASS result before public launch.
 - [ ] Confirm no production frontend switch occurs before deployed addresses and proofs are available.
 - [x] Confirm the inactive frontend helper performs only bundled static proof lookup, validates finalized metadata, and has no RPC, contract, or active UI integration.
+- [x] Confirm the isolated early-adopter UX shell is unmounted from the active app, disabled by default, informational only, and exposes no claim CTA.
 - [ ] Keep discount UI disabled and `registerWithDiscount` unwired until a separate reviewed integration passes every frontend cutover gate.
 - [ ] Before presenting a final discount action, confirm approved read paths verify root equality, frozen state, activation state, controller authorization, and already-used state; proof existence alone is insufficient.
 - [x] Confirm reusable DiscountRegistry ABI/schema/event-handler coverage exists and passes indexer codegen/build.

--- a/frontend/src/__tests__/discountFeature.test.ts
+++ b/frontend/src/__tests__/discountFeature.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+import { isEarlyAdopterDiscountUiEnabled } from "../lib/discountFeature";
+
+describe("early-adopter discount UI feature flag", () => {
+  it("is disabled by default unless explicitly set to true", () => {
+    expect(process.env.NEXT_PUBLIC_ENABLE_EARLY_ADOPTER_DISCOUNT_UI).not.toBe("true");
+    expect(isEarlyAdopterDiscountUiEnabled).toBe(false);
+  });
+});

--- a/frontend/src/components/EarlyAdopterDiscountCard.disabled.test.tsx
+++ b/frontend/src/components/EarlyAdopterDiscountCard.disabled.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("wagmi", () => ({
+  useAccount: () => ({ address: undefined, isConnected: false }),
+}));
+
+import { EarlyAdopterDiscountCard } from "./EarlyAdopterDiscountCard";
+
+describe("EarlyAdopterDiscountCard disabled gate", () => {
+  it("renders nothing when the default feature flag is disabled", () => {
+    render(<EarlyAdopterDiscountCard />);
+
+    expect(screen.queryByTestId("early-adopter-discount-card")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/EarlyAdopterDiscountCard.test.tsx
+++ b/frontend/src/components/EarlyAdopterDiscountCard.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  account: { address: undefined as `0x${string}` | undefined, isConnected: false },
+}));
+
+vi.mock("wagmi", () => ({
+  useAccount: () => mocks.account,
+}));
+
+vi.mock("../lib/discountFeature", () => ({
+  isEarlyAdopterDiscountUiEnabled: true,
+}));
+
+vi.mock("../lib/discountProofs", () => ({
+  lookupEarlyAdopterProof: vi.fn(),
+}));
+
+import { EarlyAdopterDiscountCard } from "./EarlyAdopterDiscountCard";
+import { lookupEarlyAdopterProof } from "../lib/discountProofs";
+
+const lookupMock = vi.mocked(lookupEarlyAdopterProof);
+
+afterEach(() => {
+  mocks.account = { address: undefined, isConnected: false };
+  lookupMock.mockReset();
+});
+
+describe("EarlyAdopterDiscountCard", () => {
+  it("shows a safe connect-wallet state", () => {
+    render(<EarlyAdopterDiscountCard />);
+
+    expect(screen.getByText(/connect wallet to check local eligibility/i)).toBeInTheDocument();
+    expect(screen.getByText(/discount not active yet/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("shows eligible proof without a claim CTA", async () => {
+    mocks.account = {
+      address: "0x0000b9b20ddd33cd240e8d3b7afa02fa1cdaebcc",
+      isConnected: true,
+    };
+    lookupMock.mockResolvedValue({
+      status: "eligible",
+      address: "0x0000b9b20ddd33cd240e8d3b7afa02fa1cdaebcc",
+      proof: [],
+      metadata: {} as never,
+    });
+
+    render(<EarlyAdopterDiscountCard />);
+
+    await waitFor(() => expect(screen.getByText(/eligible proof found/i)).toBeInTheDocument());
+    expect(screen.getByText(/does not mean the discount is active/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("keeps an ineligible result safe", async () => {
+    mocks.account = {
+      address: "0x0000000000000000000000000000000000000001",
+      isConnected: true,
+    };
+    lookupMock.mockResolvedValue({
+      status: "ineligible",
+      address: "0x0000000000000000000000000000000000000001",
+      reason: "missing-proof",
+    });
+
+    render(<EarlyAdopterDiscountCard />);
+
+    await waitFor(() => expect(screen.getByText(/no eligible proof found/i)).toBeInTheDocument());
+    expect(screen.queryByText(/claim|register with discount/i)).not.toBeInTheDocument();
+  });
+
+  it("fails safely when the proof artifact is unavailable", async () => {
+    mocks.account = {
+      address: "0x0000000000000000000000000000000000000001",
+      isConnected: true,
+    };
+    lookupMock.mockResolvedValue({ status: "unavailable", reason: "artifact-fetch-failed" });
+
+    render(<EarlyAdopterDiscountCard />);
+
+    await waitFor(() => expect(screen.getByText(/proof artifact unavailable/i)).toBeInTheDocument());
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});
+
+

--- a/frontend/src/components/EarlyAdopterDiscountCard.tsx
+++ b/frontend/src/components/EarlyAdopterDiscountCard.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAccount } from "wagmi";
+import {
+  lookupEarlyAdopterProof,
+  type DiscountProofLookupResult,
+} from "../lib/discountProofs";
+import { isEarlyAdopterDiscountUiEnabled } from "../lib/discountFeature";
+import { GlassCard } from "./ui/GlassCard";
+
+type EligibilityState =
+  | { status: "connect-wallet" }
+  | { status: "checking" }
+  | DiscountProofLookupResult;
+
+function statusCopy(state: EligibilityState): { title: string; detail: string } {
+  switch (state.status) {
+    case "connect-wallet":
+      return {
+        title: "Connect wallet to check local eligibility",
+        detail: "No wallet or contract action will be requested.",
+      };
+    case "checking":
+      return {
+        title: "Checking bundled proof data",
+        detail: "This local lookup does not read chain state.",
+      };
+    case "eligible":
+      return {
+        title: "Eligible proof found",
+        detail:
+          "A proof does not mean the discount is active, available, or unused. Discount registration is not available yet.",
+      };
+    case "ineligible":
+      return {
+        title: "No eligible proof found",
+        detail: "No discount action is available. This result does not affect the normal registration path.",
+      };
+    case "invalid-address":
+      return {
+        title: "Wallet address unavailable",
+        detail: "Reconnect with a valid wallet address before checking local proof data.",
+      };
+    case "unavailable":
+      return {
+        title: "Proof artifact unavailable",
+        detail: "Eligibility cannot be determined. No discount action is available.",
+      };
+  }
+}
+
+/**
+ * Inactive preview shell. It is intentionally not mounted by the active app.
+ * The component performs only a bundled static proof lookup and exposes no CTA.
+ */
+export function EarlyAdopterDiscountCard() {
+  const { address, isConnected } = useAccount();
+  const [state, setState] = useState<EligibilityState>({ status: "connect-wallet" });
+
+  useEffect(() => {
+    if (!isEarlyAdopterDiscountUiEnabled || !isConnected || !address) {
+      setState({ status: "connect-wallet" });
+      return;
+    }
+
+    let cancelled = false;
+    setState({ status: "checking" });
+
+    lookupEarlyAdopterProof(address).then((result) => {
+      if (!cancelled) setState(result);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [address, isConnected]);
+
+  if (!isEarlyAdopterDiscountUiEnabled) return null;
+
+  const copy = statusCopy(state);
+
+  return (
+    <GlassCard className="p-5" data-testid="early-adopter-discount-card">
+      <p className="text-xs font-semibold uppercase tracking-wide text-[var(--arcns-text-muted)]">
+        Early-adopter eligibility preview
+      </p>
+      <h3 className="mt-2 font-semibold text-[var(--arcns-text-primary)]">{copy.title}</h3>
+      <p className="mt-2 text-sm leading-6 text-[var(--arcns-text-secondary)]">{copy.detail}</p>
+      <p className="mt-3 text-xs font-medium text-[var(--arcns-warning)]">
+        Discount not active yet
+      </p>
+    </GlassCard>
+  );
+}

--- a/frontend/src/lib/discountFeature.ts
+++ b/frontend/src/lib/discountFeature.ts
@@ -1,0 +1,11 @@
+/**
+ * Fail-closed gate for the inactive early-adopter discount UX shell.
+ *
+ * Production must not enable this flag until the mainnet contracts are
+ * deployed, the expected root is set and frozen, activation is approved,
+ * used-state reads are available, preview smoke tests pass, and frontend
+ * cutover is approved. This gate does not select a chain, resolve contract
+ * addresses, read chain state, or authorize a discount action.
+ */
+export const isEarlyAdopterDiscountUiEnabled =
+  process.env.NEXT_PUBLIC_ENABLE_EARLY_ADOPTER_DISCOUNT_UI === "true";


### PR DESCRIPTION
This PR adds a disabled-by-default frontend shell for future early-adopter discount UX.

Included:
- Adds a fail-closed frontend discount feature flag.
- Adds an inactive EarlyAdopterDiscountCard component.
- Adds focused tests for the flag and safe UI states.
- Uses the existing static proof lookup helper only for local eligibility display.
- Updates proof delivery, frontend cutover, and security docs.

Important:
- Discount UI is disabled by default.
- The component is not mounted in the active app.
- registerWithDiscount is not wired.
- Active registration and renewal flows are unchanged.
- The frontend remains testnet-bound.
- Proof existence does not mean claim availability.
- The helper/UI does not assume root is frozen or discount is active.

Not included:
- No contract deployment.
- No frontend deployment.
- No live on-chain write.
- No signing.
- No root set/freeze/activation.
- No frontend mainnet switch.
- No active discount UI.
- No final mainnet contract addresses.
- No final mainnet subgraph endpoint.
- No env, private key, API key, or secret changes.

Validation:
- Focused frontend tests passed.
- Frontend build passed.
- Proof artifact validator passed with 849 proofs.
- git diff --check passed.
- Restricted terminology scan passed.

Remaining blockers:
- Final mainnet contract addresses.
- DiscountRegistry deployment.
- Root set/freeze ceremony.
- Discount activation approval.
- Used-state direct-read or indexer fallback.
- Mainnet indexer/subgraph deployment and sync.
- Frontend mainnet cutover.
- Preview smoke tests.
- Final launch review.