### PR TITLE
docs: add mainnet admin safe readiness plan

### DIFF
--- a/docs/mainnet/ADMIN_OWNERSHIP_PLAN.md
+++ b/docs/mainnet/ADMIN_OWNERSHIP_PLAN.md
@@ -4,13 +4,15 @@ Status: finalized administration and ownership plan for launch preparation only.
 
 ## Executive summary
 
-- ArcNS mainnet will use a 2-of-3 Admin Safe, following the same structural pattern as the testnet admin Safe. The final mainnet Safe address, owners, and threshold record are still launch blockers and must not be inferred from testnet values.
+- ArcNS mainnet will use a new 2-of-3 Admin Safe, following the same structural pattern as the testnet admin Safe. The three owner inputs are selected in [`ADMIN_SAFE_READINESS_PLAN.md`](./ADMIN_SAFE_READINESS_PLAN.md), but the final mainnet Safe address and read-only configuration verification remain launch blockers. The testnet Safe address must not be reused.
 - The deployer wallet will be the treasury recipient at launch as a deliberate operational simplification.
 - A standard 48-hour `TimelockController` is planned to hold controller and resolver upgrade authority. Its minimum delay will be `172800` seconds.
 - Emergency pause authority will be held by the Admin Safe.
 - The deployer EOA is for deployment and bootstrap only. After handoff, it must not retain admin, ownership, upgrade, root, freeze, activation, pause, oracle, resolver, registrar, registry, or discount-registry authority.
 
 The treasury recipient is not the protocol admin. Receiving protocol revenue does not, by itself, grant authority over contracts or roles.
+
+The selected deployer/treasury EOA may be one Safe owner, but it must not be recorded as the Admin Safe contract address. The Admin Safe must be a separate contract with verified bytecode, owners, and threshold on Arc mainnet.
 
 ## Final role ownership table
 
@@ -34,8 +36,8 @@ The treasury recipient is not the protocol admin. Receiving protocol revenue doe
 | DiscountRegistry owner | Admin Safe (address TBD) | Timelock migration may be considered only after launch is stable | Launch coordination includes controller authorization, root, freeze, and activation administration. | Yes — Safe address and handoff pending |
 | DiscountRegistry authorized `.arc` controller | Final deployed `.arc` controller address (TBD), authorized by DiscountRegistry owner | Same unless a reviewed controller migration occurs | Only the finalized controller may consume `.arc` campaign claims. | Yes — deployed controller address and authorization pending |
 | DiscountRegistry authorized `.circle` controller | Final deployed `.circle` controller address (TBD), authorized by DiscountRegistry owner | Same unless a reviewed controller migration occurs | Only the finalized controller may consume `.circle` campaign claims. | Yes — deployed controller address and authorization pending |
-| Treasury recipient | Deployer wallet (address TBD) | Treasury Safe recommended in a future reviewed migration | Operational simplicity at launch; this is revenue custody, not protocol administration. | Yes — final deployer/treasury address pending |
-| Deployer EOA | Deployment/bootstrap only; treasury recipient at launch | Treasury recipient only, if retained as the final launch choice | The deployer must have no lasting privileged protocol authority after handoff. | Yes — address and complete revoke verification pending |
+| Treasury recipient | Deployer wallet (`0x0b943Fe9f1f8135e0751BA8B43dc0cD688ad209D`) | Treasury Safe recommended in a future reviewed migration | Operational simplicity at launch; this is revenue custody, not protocol administration. | Yes — final operational verification pending |
+| Deployer EOA | `0x0b943Fe9f1f8135e0751BA8B43dc0cD688ad209D`; deployment/bootstrap only and treasury recipient at launch | Treasury recipient only, if retained as the final launch choice | The deployer must have no lasting privileged protocol authority after handoff. | Yes — operational and complete revoke verification pending |
 | Timelock proposer | Admin Safe (address TBD) | Same unless the authority model is deliberately revised | The Safe schedules reviewed critical operations. | Yes — Safe and Timelock deployment/configuration pending |
 | Timelock canceller | Admin Safe (address TBD) | Same unless the authority model is deliberately revised | The Safe can cancel unsafe or obsolete queued operations. | Yes — Safe and Timelock deployment/configuration pending |
 | Timelock executor | Admin Safe (address TBD) | May be changed later through a separately reviewed authority-model decision | A restricted executor is simpler for launch operations. | Yes — Safe and Timelock deployment/configuration pending |
@@ -94,8 +96,8 @@ The strictly read-only `scripts/mainnet/assert-admin-handoff.js` must verify the
 ## Launch blockers
 
 - [ ] Final mainnet Admin Safe address is not yet recorded.
-- [ ] Final Safe owner addresses and the 2-of-3 threshold are not yet recorded.
-- [ ] Final deployer/treasury address is not yet recorded in launch documentation.
+- [ ] Selected Safe owner addresses and the 2-of-3 threshold are not yet verified against a mainnet Safe.
+- [ ] Selected deployer/treasury address requires final operational verification.
 - [ ] Timelock is not deployed.
 - [ ] Timelock address is not known.
 - [ ] Role handoff and deployer revocation are not executed or verified.
@@ -125,6 +127,7 @@ Arc mainnet is not ready to deploy while any launch blocker above remains open.
 ## Related finalized preparation inputs
 
 - Mainnet pricing: [`PRICING.md`](./PRICING.md)
+- Admin Safe readiness: [`ADMIN_SAFE_READINESS_PLAN.md`](./ADMIN_SAFE_READINESS_PLAN.md)
 - Early-adopter snapshot: [`EARLY_ADOPTER_SNAPSHOT.md`](./EARLY_ADOPTER_SNAPSHOT.md)
 - Safe / Timelock / handoff ceremony: [`HANDOFF_CEREMONY_PLAN.md`](./HANDOFF_CEREMONY_PLAN.md)
 - Deployment preparation runbook: [`DEPLOYMENT_RUNBOOK.md`](./DEPLOYMENT_RUNBOOK.md)

--- a/docs/mainnet/ADMIN_SAFE_READINESS_PLAN.md
+++ b/docs/mainnet/ADMIN_SAFE_READINESS_PLAN.md
@@ -1,0 +1,123 @@
+# ArcNS Mainnet Admin Safe Readiness Plan (Aşama 7B-1)
+
+Status: readiness planning and read-only tooling preparation only. This document does not create a Safe or authorize mainnet launch.
+
+## A. Executive summary
+
+- This is a mainnet Admin Safe readiness plan, not a Safe creation execution.
+- The mainnet Admin Safe remains a launch blocker until it is created with explicit operator approval and then independently verified through read-only checks.
+- The approved model is a new Arc mainnet 2-of-3 Safe contract with the three selected owners recorded below.
+- The testnet Safe confirms the intended pattern, but `0x01BaeBec34dd426E98cA7e550Eb652235Ea7e4f3` is a testnet reference only and must not be reused as a final mainnet value.
+- The deployer and launch treasury EOA may be one Safe owner, but it cannot be recorded as the Safe contract address.
+
+## B. Mainnet Safe input table
+
+`TBD` is a launch blocker. No unknown Safe address, creation transaction hash, block, or creation method is inferred or invented by this plan.
+
+| Input | Required value | Status | Notes |
+|---|---|---|---|
+| Chain | Arc mainnet | Selected; verification pending | Safe UI, provider, and explorer evidence must identify Arc mainnet. |
+| Chain ID | `5042` | Confirmed network input; Safe verification pending | Read back from the provider used for validation. |
+| Safe type | New mainnet 2-of-3 Safe contract | Approved model; creation pending | Must be a separate smart contract on Arc mainnet. |
+| Safe threshold | `2` of `3` | Selected; verification pending | Must be read back from the created Safe. |
+| Owner 1 | `0x0b943Fe9f1f8135e0751BA8B43dc0cD688ad209D` | Selected; verification pending | May also be deployer and launch treasury recipient. |
+| Owner 2 | `0xB2F6CfD0960A1fCC532DE1BF2Aafcc3077B4c396` | Selected; verification pending | Must be present in the exact verified owner set. |
+| Owner 3 | `0x1e19c1c829A387c2246567c0df264D81310d7775` | Selected; verification pending | Must be present in the exact verified owner set. |
+| Admin Safe address | `TBD` | Blocked | Record only after creation and read-only validation; must not equal an owner EOA or the testnet Safe. |
+| Deployer / treasury recipient | `0x0b943Fe9f1f8135e0751BA8B43dc0cD688ad209D` | Selected; final launch verification pending | Treasury receipt is separate from protocol admin authority. |
+| Safe creation method | `TBD` | Blocked | Approved interface or reviewed deployment method must be selected before execution. |
+| Safe creation transaction hash | `TBD` | Blocked | Produced only by a future explicitly approved Safe creation. |
+| Safe creation block | `TBD` | Blocked | Reconcile against the future creation receipt and Arc mainnet block. |
+| Safe verification status | Not verified | Blocked | Requires bytecode, chain, exact owner-set, threshold, and address-separation checks. |
+
+## C. Owner model
+
+- Owner 1: `0x0b943Fe9f1f8135e0751BA8B43dc0cD688ad209D`
+- Owner 2: `0xB2F6CfD0960A1fCC532DE1BF2Aafcc3077B4c396`
+- Owner 3: `0x1e19c1c829A387c2246567c0df264D81310d7775`
+- Threshold: `2` of `3`.
+- Owner 1 may also be the deployer and launch treasury recipient.
+- A 2-of-3 threshold means any two owners must sign a Safe transaction before it can execute.
+- Loss of access to one owner key should not block operations because the other two owners can still satisfy the threshold.
+- A single owner must not be able to execute protocol admin actions.
+
+Owner addresses are selected inputs, not verified Safe configuration, until the created mainnet Safe returns the exact owner set and threshold through read-only calls.
+
+## D. Safe creation plan
+
+This is a dry-run plan for a future separately approved operation. Do not create a Safe while following this readiness document.
+
+1. Open the approved Safe creation interface or reviewed Safe deployment method.
+2. Select Arc mainnet and confirm chain ID `5042`.
+3. Add exactly the three approved owner addresses recorded in this plan.
+4. Set the threshold to `2`.
+5. Review that the resulting Safe address is a contract address distinct from every owner EOA.
+6. Create the Safe only after explicit operator approval.
+7. Record the Safe address, creation transaction hash, and creation block.
+8. Run read-only Safe configuration validation.
+9. Update the mainnet launch inputs only after every validation passes.
+
+Do not record or expose raw private keys, seed phrases, secret RPC URLs, wallet credentials, or API keys in the execution record.
+
+## E. Mainnet Safe validation checklist
+
+- [ ] The Safe address has non-empty bytecode on Arc mainnet.
+- [ ] `getOwners()` returns exactly the three approved owners.
+- [ ] `getThreshold()` returns `2`.
+- [ ] The Safe address is not equal to the deployer or any owner EOA.
+- [ ] The Safe address is recorded in launch inputs only after verification.
+- [ ] The Safe interface or explorer confirms Arc mainnet chain ID `5042`.
+- [ ] Owner order may differ, but the case-insensitive owner set matches exactly.
+- [ ] No unknown owner exists.
+- [ ] The threshold is not `1`.
+- [ ] The threshold is not `3` unless the owner model is explicitly re-approved.
+- [ ] The Safe address is not the testnet Safe address.
+
+The read-only helper [`../../scripts/mainnet/check-safe-config.js`](../../scripts/mainnet/check-safe-config.js) covers provider chain ID, bytecode, exact owner set, threshold, and Safe-versus-owner address separation. Its PASS result is necessary but does not replace independent interface, explorer, receipt, and operator review.
+
+## F. Relationship to Timelock
+
+- The mainnet Timelock remains `TBD` until the Admin Safe exists and passes validation.
+- Timelock proposer, canceller, and executor should point to the verified Admin Safe.
+- Timelock deployment should occur only after the Safe address is validated.
+- The intended Timelock minimum delay is `172800` seconds.
+- Upgrade authority should later move to the Timelock according to [`HANDOFF_CEREMONY_PLAN.md`](./HANDOFF_CEREMONY_PLAN.md).
+
+## G. Relationship to deployer / treasury
+
+- Deployer and launch treasury recipient: `0x0b943Fe9f1f8135e0751BA8B43dc0cD688ad209D`.
+- This address may be one Safe owner.
+- The treasury recipient is not protocol admin authority.
+- The deployer must not retain protocol admin authority after handoff.
+- The Safe contract address must not be this EOA.
+
+## H. Remaining blockers
+
+- [ ] Mainnet Safe is not created.
+- [ ] Mainnet Safe address is `TBD`.
+- [ ] Safe creation transaction hash and block are `TBD`.
+- [ ] Safe configuration is not verified.
+- [ ] Timelock is not deployed.
+- [ ] Timelock address is `TBD`.
+- [ ] Deploy-grade RPC is unresolved.
+- [ ] Blockscout verification is unresolved.
+- [ ] Contract deployment is not performed.
+- [ ] Handoff is not executed.
+- [ ] Final launch review is missing.
+
+The mainnet Admin Safe is not ready, and ArcNS is not ready to deploy, while these blockers remain open.
+
+## I. Non-goals
+
+- This document does not create a Safe.
+- This document does not deploy contracts.
+- This document does not deploy `TimelockController`.
+- This document does not sign or submit transactions.
+- This document does not call write functions.
+- This document does not transfer ownership or roles.
+- This document does not grant or revoke roles.
+- This document does not set prices.
+- This document does not set or freeze a Merkle root.
+- This document does not activate a discount.
+- This document does not approve mainnet launch.
+- This document does not modify environment files, secrets, credentials, or real deployment artifacts.

--- a/docs/mainnet/HANDOFF_CEREMONY_PLAN.md
+++ b/docs/mainnet/HANDOFF_CEREMONY_PLAN.md
@@ -9,7 +9,7 @@ Status: operational planning only. This document describes a future ceremony; it
 - The approved launch model is a 2-of-3 Admin Safe, a 48-hour `TimelockController`, the deployer wallet as the launch treasury recipient, and the Admin Safe as emergency pause authority.
 - The deployer EOA is limited to deployment and bootstrap. After handoff it must retain no protocol authority and may remain only the treasury recipient if that remains the final reviewed launch choice.
 
-The consolidated launch inputs and Go/No-Go matrix are tracked in [`MAINNET_LAUNCH_INPUTS.md`](./MAINNET_LAUNCH_INPUTS.md).
+The consolidated launch inputs and Go/No-Go matrix are tracked in [`MAINNET_LAUNCH_INPUTS.md`](./MAINNET_LAUNCH_INPUTS.md). Safe creation inputs and read-only validation gates are tracked in [`ADMIN_SAFE_READINESS_PLAN.md`](./ADMIN_SAFE_READINESS_PLAN.md).
 
 ## Required addresses checklist
 
@@ -17,12 +17,12 @@ The consolidated launch inputs and Go/No-Go matrix are tracked in [`MAINNET_LAUN
 
 | Item | Required value | Status | Notes |
 |---|---|---|---|
-| Deployer EOA | `TBD` | Blocked | Deployment/bootstrap only; no protocol authority after handoff. |
-| Treasury recipient | `TBD` | Blocked | Approved launch choice is the deployer wallet, but its final address is not recorded. |
-| Admin Safe address | `TBD` | Blocked | Must be the independently verified final mainnet Safe. |
-| Admin Safe owner 1 | `TBD` | Blocked | Final owner address must be operationally verified. |
-| Admin Safe owner 2 | `TBD` | Blocked | Final owner address must be operationally verified. |
-| Admin Safe owner 3 | `TBD` | Blocked | Final owner address must be operationally verified. |
+| Deployer EOA | `0x0b943Fe9f1f8135e0751BA8B43dc0cD688ad209D` | Selected; final verification pending | Deployment/bootstrap only; no protocol authority after handoff. |
+| Treasury recipient | `0x0b943Fe9f1f8135e0751BA8B43dc0cD688ad209D` | Selected; final verification pending | Approved launch choice is the deployer wallet; treasury receipt is not protocol authority. |
+| Admin Safe address | `TBD` | Blocked | Must be the independently verified final mainnet Safe contract and must not equal the deployer or any owner EOA. |
+| Admin Safe owner 1 | `0x0b943Fe9f1f8135e0751BA8B43dc0cD688ad209D` | Selected; Safe verification pending | May also be the deployer/treasury EOA. |
+| Admin Safe owner 2 | `0xB2F6CfD0960A1fCC532DE1BF2Aafcc3077B4c396` | Selected; Safe verification pending | Exact owner-set read-back required. |
+| Admin Safe owner 3 | `0x1e19c1c829A387c2246567c0df264D81310d7775` | Selected; Safe verification pending | Exact owner-set read-back required. |
 | Admin Safe threshold | `2-of-3` | Approved model; verification pending | Final Safe configuration must be operationally verified before the ceremony. |
 | TimelockController address | `TBD` | Blocked | Timelock is not deployed. |
 | Timelock minDelay | `172800` seconds | Approved | Equivalent to 48 hours; deployed read-back must match. |
@@ -79,14 +79,14 @@ Deployment and handoff remain one incomplete launch operation until all required
 
 ## Read-only assertion script inputs
 
-The following names come directly from `scripts/mainnet/assert-admin-handoff.js`. All values are currently `TBD`. Explicit deployed-contract variables take precedence; alternatively, `DEPLOYMENT_ARTIFACT_PATH` may point to a reviewed JSON file whose `contracts` object contains the corresponding camel-case keys. This plan does not create or modify that artifact.
+The following names come directly from `scripts/mainnet/assert-admin-handoff.js`. The deployer and treasury inputs are selected but pending final verification; Safe, Timelock, and deployed-contract values remain `TBD`. Explicit deployed-contract variables take precedence; alternatively, `DEPLOYMENT_ARTIFACT_PATH` may point to a reviewed JSON file whose `contracts` object contains the corresponding camel-case keys. This plan does not create or modify that artifact.
 
 | Variable name | Expected value | Source of value | Known or TBD |
 |---|---|---|---|
 | `EXPECTED_ADMIN_SAFE_ADDRESS` | Final Admin Safe address | Independently verified Safe record | `TBD` |
 | `EXPECTED_TIMELOCK_ADDRESS` | Final TimelockController address | Verified Timelock deployment record | `TBD` |
-| `EXPECTED_TREASURY_RECIPIENT` | Final launch treasury recipient | Final launch approval; intended to equal deployer wallet | `TBD` |
-| `EXPECTED_DEPLOYER_ADDRESS` | Mainnet deployer EOA | Final deployment operator record | `TBD` |
+| `EXPECTED_TREASURY_RECIPIENT` | `0x0b943Fe9f1f8135e0751BA8B43dc0cD688ad209D` | Selected launch input; independently verify before use | Selected; final verification pending |
+| `EXPECTED_DEPLOYER_ADDRESS` | `0x0b943Fe9f1f8135e0751BA8B43dc0cD688ad209D` | Selected deployment operator input; independently verify before use | Selected; final verification pending |
 | `DEPLOYMENT_ARTIFACT_PATH` | Optional path to reviewed deployment JSON | Final deployment output; omit when every contract variable below is supplied | `TBD` / optional |
 | `DEPLOYED_REGISTRY_ADDRESS` | Registry address | Explicit final deployment record, or artifact key `registry` | `TBD` |
 | `DEPLOYED_ARC_REGISTRAR_ADDRESS` | `.arc` registrar address | Explicit final deployment record, or artifact key `arcRegistrar` | `TBD` |
@@ -132,6 +132,7 @@ Do not run this template with placeholders. Before a future run, replace every p
 - If either controller's treasury does not match the finalized treasury recipient, stop and correct it before launch.
 - If any Timelock role or expected upgrade-holder check mismatches, stop and correct the role configuration before upgrades are possible. Timelock internal role and delay verification is a separate required read-only check because the current assertion script does not inspect it.
 - If the Admin Safe owners and 2-of-3 threshold cannot be operationally verified, stop. Do not deploy or begin the handoff ceremony.
+- Run the read-only `scripts/mainnet/check-safe-config.js` against the final Safe and require PASS before recording its address or deploying the Timelock.
 - Record the failure and independently review the correction and all resulting final-state reads before rerunning the complete assertion.
 
 ## Discount lifecycle dependency
@@ -144,8 +145,8 @@ Do not run this template with placeholders. Before a future run, replace every p
 ## Remaining blockers
 
 - [ ] Final Admin Safe address is `TBD`.
-- [ ] Final Safe owners and operationally verified 2-of-3 threshold are `TBD`.
-- [ ] Final deployer/treasury address is `TBD`.
+- [ ] Selected Safe owners and the 2-of-3 threshold are not yet verified against a mainnet Safe.
+- [ ] Selected deployer/treasury address still requires final operational verification.
 - [ ] Timelock is not deployed.
 - [ ] Timelock address is `TBD`.
 - [ ] Contract addresses are `TBD` until deployment.
@@ -175,7 +176,9 @@ Arc mainnet is not ready to deploy while any blocker remains open. Completing th
 ## Related documents and tooling
 
 - Authority model: [`ADMIN_OWNERSHIP_PLAN.md`](./ADMIN_OWNERSHIP_PLAN.md)
+- Admin Safe readiness: [`ADMIN_SAFE_READINESS_PLAN.md`](./ADMIN_SAFE_READINESS_PLAN.md)
 - Deployment preparation: [`DEPLOYMENT_RUNBOOK.md`](./DEPLOYMENT_RUNBOOK.md)
 - Launch checks: [`SECURITY_CHECKLIST.md`](./SECURITY_CHECKLIST.md)
 - Focused review: [`FOCUSED_SECURITY_REVIEW.md`](./FOCUSED_SECURITY_REVIEW.md)
 - Read-only handoff assertion: [`../../scripts/mainnet/assert-admin-handoff.js`](../../scripts/mainnet/assert-admin-handoff.js)
+- Read-only Safe configuration check: [`../../scripts/mainnet/check-safe-config.js`](../../scripts/mainnet/check-safe-config.js)

--- a/docs/mainnet/MAINNET_LAUNCH_INPUTS.md
+++ b/docs/mainnet/MAINNET_LAUNCH_INPUTS.md
@@ -18,14 +18,14 @@ Status: input register and readiness planning only. This document is not launch 
 
 | Input | Required value | Status | Source / owner | Validation method | Blocks deploy? |
 |---|---|---|---|---|---|
-| Deployer EOA | `TBD` | Blocked | Deployment operator / final launch review | Independently verify address, operator control, and deployment-only authority boundary | Yes |
+| Deployer EOA | `0x0b943Fe9f1f8135e0751BA8B43dc0cD688ad209D` | Selected; final verification pending | Deployment operator / final launch review | Independently verify address, operator control, and deployment-only authority boundary | Yes |
 | Deployer funding requirement | `TBD` | Blocked | Deployment operator / infrastructure owner | Reviewed gas estimate, fee buffer, and read-only balance check before ceremony | Yes |
-| Treasury recipient | Final deployer EOA address (`TBD`) | Blocked | Approved authority model / final launch review | Confirm exact equality with finalized deployer address and controller treasury read-back after deployment | Yes |
-| Admin Safe address | `TBD` | Blocked | Safe operators / final launch review | Independently verify chain, address, bytecode, owners, and threshold | Yes |
-| Admin Safe owner 1 | `TBD` | Blocked | Safe operators | Independent owner identity/address confirmation and Safe read-back | Yes |
-| Admin Safe owner 2 | `TBD` | Blocked | Safe operators | Independent owner identity/address confirmation and Safe read-back | Yes |
-| Admin Safe owner 3 | `TBD` | Blocked | Safe operators | Independent owner identity/address confirmation and Safe read-back | Yes |
-| Admin Safe threshold | `2-of-3` | Approved model; verification pending | [`ADMIN_OWNERSHIP_PLAN.md`](./ADMIN_OWNERSHIP_PLAN.md) | Read-only Safe threshold and owner-set verification | Yes |
+| Treasury recipient | `0x0b943Fe9f1f8135e0751BA8B43dc0cD688ad209D` | Selected; final verification pending | Approved authority model / final launch review | Confirm exact equality with finalized deployer address and controller treasury read-back after deployment | Yes |
+| Admin Safe address | `TBD` | Blocked | Safe operators / final launch review | Independently verify chain, address, bytecode, owners, and threshold; must not equal the deployer or an owner EOA | Yes |
+| Admin Safe owner 1 | `0x0b943Fe9f1f8135e0751BA8B43dc0cD688ad209D` | Selected; Safe verification pending | Safe operators | Independent owner identity/address confirmation and Safe read-back | Yes |
+| Admin Safe owner 2 | `0xB2F6CfD0960A1fCC532DE1BF2Aafcc3077B4c396` | Selected; Safe verification pending | Safe operators | Independent owner identity/address confirmation and Safe read-back | Yes |
+| Admin Safe owner 3 | `0x1e19c1c829A387c2246567c0df264D81310d7775` | Selected; Safe verification pending | Safe operators | Independent owner identity/address confirmation and Safe read-back | Yes |
+| Admin Safe threshold | `2-of-3` | Approved model; verification pending | [`ADMIN_SAFE_READINESS_PLAN.md`](./ADMIN_SAFE_READINESS_PLAN.md) | Read-only Safe threshold and exact owner-set verification | Yes |
 | Timelock minDelay | `172800` seconds (48 hours) | Approved input; deployed read-back pending | [`ADMIN_OWNERSHIP_PLAN.md`](./ADMIN_OWNERSHIP_PLAN.md) | Read-only `getMinDelay()` against final Timelock | Yes |
 | Timelock proposer | Admin Safe (`TBD` address) | Blocked | Approved authority model / Safe operators | Read-only Timelock role membership check | Yes |
 | Timelock canceller | Admin Safe (`TBD` address) | Blocked | Approved authority model / Safe operators | Read-only Timelock role membership check | Yes |
@@ -83,7 +83,7 @@ All values in this section remain `TBD` until produced by a reviewed future depl
 | Proof artifact | Generated and validated with 849 entries | Validator PASS against finalized snapshot/root | GO | Delivery integration and used-state checks remain incomplete |
 | DiscountRegistry contract logic | Focused logic review and tests completed | Reviewed contract behavior and final launch re-review | GO | Deployment and runtime configuration remain separate gates |
 | Launch tooling guards | Fail-closed guards and separated lifecycle scripts prepared | Code review and syntax/tests already recorded; final operator review | GO | Write-capable scripts have not been run here |
-| Admin Safe | Address, owners, and verification are `TBD` | Final 2-of-3 Safe address, owner set, threshold, chain, and bytecode evidence | NO-GO | Safe is not created by this phase |
+| Admin Safe | Owner inputs and 2-of-3 model selected; address and verification are `TBD` | Final 2-of-3 Safe address, exact owner set, threshold, chain, and bytecode evidence | NO-GO | Safe is not created by this phase; deployer EOA must not be used as its contract address |
 | Timelock | Not deployed; address and final bootstrap setup `TBD` | Final deployment plus 172800-second delay and complete role/admin reads | NO-GO | Timelock is not deployed by this phase |
 | Deployer revocation | Not executed or verified | Complete handoff evidence and read-only assertion PASS, plus checks outside script coverage | NO-GO | Deployer must retain no protocol authority |
 | Deploy-grade RPC | Not approved | Provider ownership, masked endpoint, repeated readiness evidence, preflight PASS, explicit approval | NO-GO | Radar remains read-only/testing fallback only |
@@ -111,6 +111,7 @@ Commands are recorded for future reviewed use. Environment values must be suppli
 | `node scripts/mainnet/check-blockscout-readiness.js` | Harmless JSON reachability and API compatibility classification | `ARC_MAINNET_EXPLORER_API_URL` as a real HTTPS candidate; no API key required by the checker | Read-only HTTP GET | When the explorer owner supplies a reviewed API candidate; no verification submission | No; final API candidate is `TBD` |
 | `npx hardhat run scripts/preflight-arc-mainnet.js --network arc_mainnet` | Assert chain `5042`, latest block, and known USDC bytecode/symbol/decimals | Configured `arc_mainnet` read provider, normally via transient `ARC_MAINNET_RPC_URL` | Read-only network calls | Provider evaluation and final pre-deployment preflight only | Conditional for read-only fallback; not evidence of deploy-grade approval |
 | `node scripts/mainnet/validate-discount-proof-artifact.js` | Validate finalized artifact metadata, count, and every Merkle proof | Version-controlled finalized snapshot and bundled proof artifact; no env, signer, or RPC | Read-only, local and network-free | Any review/CI context | Yes |
+| `node scripts/mainnet/check-safe-config.js` | Validate Safe chain, bytecode, exact owner set, threshold, and separation from owner EOAs | `SAFE_RPC_URL`, `EXPECTED_CHAIN_ID`, `ADMIN_SAFE_ADDRESS`, comma-separated `EXPECTED_SAFE_OWNERS`, and `EXPECTED_SAFE_THRESHOLD`; RPC output is masked | Read-only network calls; no signer | After Safe creation, before recording the address in launch inputs; may also validate the testnet reference | No for mainnet; Admin Safe address is `TBD` |
 | `npx hardhat run scripts/mainnet/assert-admin-handoff.js --network arc_mainnet` | Assert configured owners, roles, treasury, bytecode, and deployer revocation | Final expected Safe, Timelock, treasury, deployer, and all contract addresses, or reviewed artifact path; read provider | Read-only network calls | Only after final deployment and handoff, before public launch | No; final addresses/deployment/handoff are missing |
 | `npx hardhat run scripts/mainnet/discount-set-root.js --network arc_mainnet` | Set only the finalized DiscountRegistry Merkle root after state/owner guards | `CONFIRM_MAINNET_WRITE=YES`, final registry and expected owner, Arc mainnet provider and signer; canonical snapshot | **Write-capable; signs and submits a transaction** | Only in a separately approved post-deployment ceremony after verification and handoff prerequisites | No; forbidden in this task and prerequisites are incomplete |
 | `npx hardhat run scripts/mainnet/discount-freeze-root.js --network arc_mainnet` | Irreversibly freeze the finalized root after exact read-back guards | `CONFIRM_MAINNET_WRITE=YES`, final registry and expected owner, Arc mainnet provider and signer; exact root already set | **Write-capable and irreversible; signs and submits a transaction** | Only in a separate independently reviewed freeze ceremony | No; forbidden in this task and root is not set |
@@ -122,8 +123,8 @@ The read-only handoff assertion has documented coverage limits: Safe owners/thre
 
 ### Inputs missing
 
-- Final deployer EOA, funding requirement, and treasury address.
-- Final Admin Safe address, three owners, and verified 2-of-3 configuration.
+- Deployer funding requirement and final deployer/treasury operational verification.
+- Final Admin Safe address and verified exact selected-owner 2-of-3 configuration.
 - Final deploy-grade RPC provider/masked endpoint and approved Blockscout API/key/verification path.
 - Final indexer target and frontend preview, production, and rollback owners.
 
@@ -184,6 +185,7 @@ The read-only handoff assertion has documented coverage limits: Safe owners/thre
 ## Related plans
 
 - Deployment runbook: [`DEPLOYMENT_RUNBOOK.md`](./DEPLOYMENT_RUNBOOK.md)
+- Admin Safe readiness: [`ADMIN_SAFE_READINESS_PLAN.md`](./ADMIN_SAFE_READINESS_PLAN.md)
 - Authority model: [`ADMIN_OWNERSHIP_PLAN.md`](./ADMIN_OWNERSHIP_PLAN.md)
 - Handoff ceremony: [`HANDOFF_CEREMONY_PLAN.md`](./HANDOFF_CEREMONY_PLAN.md)
 - Infrastructure readiness: [`DEPLOY_INFRA_READINESS.md`](./DEPLOY_INFRA_READINESS.md)

--- a/docs/mainnet/SECURITY_CHECKLIST.md
+++ b/docs/mainnet/SECURITY_CHECKLIST.md
@@ -10,7 +10,10 @@ Proof delivery evidence: [`PROOF_DELIVERY_PLAN.md`](./PROOF_DELIVERY_PLAN.md).
 
 Consolidated launch inputs and Go/No-Go readiness: [`MAINNET_LAUNCH_INPUTS.md`](./MAINNET_LAUNCH_INPUTS.md).
 
+Admin Safe creation and read-only validation readiness: [`ADMIN_SAFE_READINESS_PLAN.md`](./ADMIN_SAFE_READINESS_PLAN.md).
+
 - [ ] Confirm every ownership, admin, upgrade, pause, treasury, and deployer-revocation item in [`ADMIN_OWNERSHIP_PLAN.md`](./ADMIN_OWNERSHIP_PLAN.md).
+- [ ] Confirm the Admin Safe is a separate Arc mainnet contract, not the deployer or an owner EOA, and run the read-only `scripts/mainnet/check-safe-config.js` with the selected owner set and threshold `2` before recording its address.
 - [ ] Execute and verify the separately reviewed future ceremony in [`HANDOFF_CEREMONY_PLAN.md`](./HANDOFF_CEREMONY_PLAN.md) before launch.
 - [ ] Confirm standard oracle reads are 100/50/25/15/5 USDC in p1..p5 order.
 - [ ] Confirm normal `register()` and `renew()` remain the standard paths.

--- a/scripts/mainnet/check-safe-config.js
+++ b/scripts/mainnet/check-safe-config.js
@@ -1,0 +1,135 @@
+"use strict";
+
+const { ethers } = require("ethers");
+
+const SAFE_ABI = [
+  "function getOwners() view returns (address[])",
+  "function getThreshold() view returns (uint256)",
+];
+const REQUIRED_ENV = [
+  "SAFE_RPC_URL",
+  "EXPECTED_CHAIN_ID",
+  "ADMIN_SAFE_ADDRESS",
+  "EXPECTED_SAFE_OWNERS",
+  "EXPECTED_SAFE_THRESHOLD",
+];
+const PLACEHOLDER_PATTERN = /^(?:tbd|todo|null|undefined|placeholder|changeme|replace_me|<.*>)$/i;
+
+function requiredValue(env, name) {
+  const value = String(env[name] || "").trim();
+  if (!value || PLACEHOLDER_PATTERN.test(value)) {
+    throw new Error(`${name} is required and must not be empty or a placeholder`);
+  }
+  return value;
+}
+
+function positiveInteger(value, name) {
+  if (!/^\d+$/.test(value) || BigInt(value) < 1n) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return BigInt(value);
+}
+
+function checkedAddress(value, name) {
+  try {
+    return ethers.getAddress(value);
+  } catch (_) {
+    throw new Error(`${name} must be a valid address`);
+  }
+}
+
+function maskRpcUrl(value) {
+  try {
+    const url = new URL(value);
+    return `${url.protocol}//${url.host}/***`;
+  } catch (_) {
+    return "<masked-invalid-url>";
+  }
+}
+
+function loadConfig(env = process.env) {
+  for (const name of REQUIRED_ENV) requiredValue(env, name);
+
+  const rpcUrl = requiredValue(env, "SAFE_RPC_URL");
+  let parsedRpc;
+  try {
+    parsedRpc = new URL(rpcUrl);
+  } catch (_) {
+    throw new Error("SAFE_RPC_URL must be a valid HTTP(S) URL");
+  }
+  if (!/^https?:$/.test(parsedRpc.protocol)) {
+    throw new Error("SAFE_RPC_URL must use HTTP or HTTPS");
+  }
+
+  const ownerEntries = requiredValue(env, "EXPECTED_SAFE_OWNERS").split(",").map((owner) => owner.trim());
+  if (ownerEntries.some((owner) => !owner || PLACEHOLDER_PATTERN.test(owner))) {
+    throw new Error("EXPECTED_SAFE_OWNERS must not contain empty or placeholder entries");
+  }
+  const owners = ownerEntries
+    .map((owner, index) => checkedAddress(owner, `EXPECTED_SAFE_OWNERS entry ${index + 1}`));
+
+  const normalizedOwners = owners.map((owner) => owner.toLowerCase());
+  if (new Set(normalizedOwners).size !== owners.length) {
+    throw new Error("EXPECTED_SAFE_OWNERS must not contain duplicates");
+  }
+
+  const threshold = positiveInteger(requiredValue(env, "EXPECTED_SAFE_THRESHOLD"), "EXPECTED_SAFE_THRESHOLD");
+  if (threshold > BigInt(owners.length)) {
+    throw new Error("EXPECTED_SAFE_THRESHOLD must not exceed the expected owner count");
+  }
+
+  const safeAddress = checkedAddress(requiredValue(env, "ADMIN_SAFE_ADDRESS"), "ADMIN_SAFE_ADDRESS");
+  if (normalizedOwners.includes(safeAddress.toLowerCase())) {
+    throw new Error("ADMIN_SAFE_ADDRESS must not equal any expected owner address");
+  }
+
+  return {
+    rpcUrl,
+    expectedChainId: positiveInteger(requiredValue(env, "EXPECTED_CHAIN_ID"), "EXPECTED_CHAIN_ID"),
+    safeAddress,
+    owners,
+    threshold,
+  };
+}
+
+async function main() {
+  const config = loadConfig();
+  console.log(`RPC: ${maskRpcUrl(config.rpcUrl)}`);
+
+  const provider = new ethers.JsonRpcProvider(config.rpcUrl);
+  const network = await provider.getNetwork();
+  if (network.chainId !== config.expectedChainId) {
+    throw new Error(`Chain ID mismatch: expected ${config.expectedChainId}, received ${network.chainId}`);
+  }
+
+  const code = await provider.getCode(config.safeAddress);
+  if (code === "0x") throw new Error("ADMIN_SAFE_ADDRESS has no bytecode");
+
+  const safe = new ethers.Contract(config.safeAddress, SAFE_ABI, provider);
+  const [actualOwners, actualThreshold] = await Promise.all([safe.getOwners(), safe.getThreshold()]);
+  const expectedSet = new Set(config.owners.map((owner) => owner.toLowerCase()));
+  const actualNormalized = actualOwners.map((owner) => checkedAddress(owner, "Safe owner").toLowerCase());
+  const actualSet = new Set(actualNormalized);
+
+  if (actualSet.size !== actualOwners.length) throw new Error("Safe returned duplicate owners");
+  if (actualSet.size !== expectedSet.size || [...expectedSet].some((owner) => !actualSet.has(owner))) {
+    throw new Error("Safe owner set does not exactly match EXPECTED_SAFE_OWNERS");
+  }
+  if (actualThreshold !== config.threshold) {
+    throw new Error(`Safe threshold mismatch: expected ${config.threshold}, received ${actualThreshold}`);
+  }
+  if (actualNormalized.includes(config.safeAddress.toLowerCase())) {
+    throw new Error("Safe address must not equal an owner address");
+  }
+
+  console.log(`PASS: Safe ${config.safeAddress} has bytecode, exact expected owners, threshold ${actualThreshold}, and chain ID ${network.chainId} (read-only).`);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(`FAIL: ${error.message.replace(/https?:\/\/[^\s)]+/gi, "<masked-rpc-url>")}`);
+    process.exit(1);
+  });
+}
+
+module.exports = { loadConfig, main, maskRpcUrl };


### PR DESCRIPTION
This PR adds the ArcNS mainnet Admin Safe readiness plan and a read-only Safe configuration checker for Aşama 7B-1.

Included:
- Adds docs/mainnet/ADMIN_SAFE_READINESS_PLAN.md.
- Adds scripts/mainnet/check-safe-config.js.
- Updates mainnet launch inputs, handoff ceremony, admin ownership, and security checklist docs.
- Records the selected 2-of-3 mainnet Admin Safe owner model.
- Keeps the mainnet Admin Safe address as TBD until a new Safe is created and read-only verified.
- Clarifies that the deployer/treasury EOA may be one Safe owner but must not be used as the Safe contract address.
- Adds a read-only checker for chain ID, Safe bytecode, owner set, threshold, and Safe/owner separation.

Important:
- Mainnet Admin Safe is not ready yet.
- Mainnet deployment is not ready.
- Testnet Safe is reference-only and must not be copied into the mainnet Admin Safe field.
- The Safe checker is read-only and creates no signer.

Not included:
- No Safe creation.
- No contract deployment.
- No Timelock deployment.
- No frontend deployment.
- No subgraph deployment.
- No live on-chain write.
- No transaction signing or submission.
- No contract verification submission.
- No ownership or role transfer.
- No price/root/freeze/activation operation.
- No env, private key, wallet credential, API key, or secret changes.
- No real deployment artifact changes.

Validation:
- node --check scripts/mainnet/check-safe-config.js passed.
- git diff --check passed.
- Restricted terminology scans passed.
- No Hardhat tests or frontend build required because no contract/frontend behavior changed.

Remaining blockers:
- Mainnet Admin Safe must be created.
- Mainnet Safe address, creation tx, and block remain TBD.
- Safe config must be verified on Arc mainnet.
- Timelock remains undeployed.
- Deploy-grade RPC and Blockscout verification path remain unresolved.
- Mainnet contracts, handoff, indexer, frontend cutover, and final launch review remain outstanding.