### PR TITLE
fix: disable batching in safe config checker

### DIFF
--- a/scripts/mainnet/check-safe-config.js
+++ b/scripts/mainnet/check-safe-config.js
@@ -96,7 +96,8 @@ async function main() {
   const config = loadConfig();
   console.log(`RPC: ${maskRpcUrl(config.rpcUrl)}`);
 
-  const provider = new ethers.JsonRpcProvider(config.rpcUrl);
+  // Disable batching for RPC providers that reject JSON-RPC batch requests.
+  const provider = new ethers.JsonRpcProvider(config.rpcUrl, config.expectedChainId, { batchMaxCount: 1 });
   const network = await provider.getNetwork();
   if (network.chainId !== config.expectedChainId) {
     throw new Error(`Chain ID mismatch: expected ${config.expectedChainId}, received ${network.chainId}`);


### PR DESCRIPTION
This PR fixes the read-only mainnet Safe configuration checker so it works with RPC providers that reject JSON-RPC batch requests.

Included:
- Updates scripts/mainnet/check-safe-config.js to construct the ethers provider with batchMaxCount: 1.
- Adds a short compatibility comment explaining why batching is disabled.
- Keeps the checker fully read-only.
- Keeps all existing validations:
  - required env checks
  - placeholder rejection
  - chain ID check
  - Safe bytecode check
  - getOwners()
  - getThreshold()
  - owner set comparison
  - threshold comparison
  - Safe address must not equal any expected owner
  - RPC URL masking

Validation:
- node --check scripts/mainnet/check-safe-config.js passed.
- git diff --check passed.
- Restricted terminology scan passed.
- Read-only checker passed against the newly created Arc mainnet Admin Safe using the Radar read-only RPC.

Verified read-only result:
- Chain ID: 5042
- Safe: 0xFd48189D3Feb99a5cC6fcC6896744DAa73F3BF72
- Bytecode present
- Expected owners matched exactly
- Threshold: 2
- Safe address is not an owner EOA

Not included:
- No Safe creation.
- No contract deployment.
- No Timelock deployment.
- No live on-chain write.
- No signing.
- No ownership or role changes.
- No env, secret, private key, API key, or deployment artifact changes.

Remaining blockers:
- Safe creation tx/block still need to be recorded.
- Timelock remains undeployed.
- Deploy-grade RPC and Blockscout verification path remain unresolved.
- Mainnet contracts, handoff, indexer, frontend cutover, and final launch review remain outstanding.