### PR TITLE
docs: add mainnet timelock readiness plan

### DIFF
--- a/docs/mainnet/ADMIN_OWNERSHIP_PLAN.md
+++ b/docs/mainnet/ADMIN_OWNERSHIP_PLAN.md
@@ -7,6 +7,7 @@ Status: finalized administration and ownership plan for launch preparation only.
 - ArcNS mainnet uses the verified new 2-of-3 Admin Safe `0xFd48189D3Feb99a5cC6fcC6896744DAa73F3BF72`, following the same structural pattern as the testnet admin Safe. Safe creation and configuration verification are complete; the testnet Safe address must not be reused.
 - The deployer wallet will be the treasury recipient at launch as a deliberate operational simplification.
 - A standard 48-hour `TimelockController` is planned to hold controller and resolver upgrade authority. Its minimum delay will be `172800` seconds.
+- Timelock readiness is documented in [`TIMELOCK_READINESS_PLAN.md`](./TIMELOCK_READINESS_PLAN.md). It is the next authority blocker, is not deployed, and its address remains `TBD`; mainnet remains **NO-GO**.
 - Emergency pause authority will be held by the Admin Safe.
 - The deployer EOA is for deployment and bootstrap only. After handoff, it must not retain admin, ownership, upgrade, root, freeze, activation, pause, oracle, resolver, registrar, registry, or discount-registry authority.
 
@@ -91,7 +92,7 @@ These are future launch actions, not actions performed by this documentation pha
 
 Every transfer, grant, revoke, authorization, address assignment, and final role read must be independently reviewed against the finalized deployed addresses before mainnet activation.
 
-The strictly read-only `scripts/mainnet/assert-admin-handoff.js` must verify the finalized Safe, Timelock, treasury, deployed addresses, owners, roles, and deployer revocation before public launch. It does not execute the handoff and must not be treated as proof until run against the final deployment with independently reviewed expected values.
+The strictly read-only `scripts/mainnet/assert-admin-handoff.js` must verify the finalized Safe, Timelock, treasury, deployed addresses, owners, roles, and deployer revocation before public launch. The future read-only `scripts/mainnet/check-timelock-config.js` must separately verify Timelock delay, internal roles, self-administration, and optional deployer-admin absence after deployment. Neither checker executes the handoff, and neither must be treated as proof until run against final deployments with independently reviewed expected values.
 
 ## Launch blockers
 
@@ -128,6 +129,7 @@ Arc mainnet is not ready to deploy while any launch blocker above remains open.
 
 - Mainnet pricing: [`PRICING.md`](./PRICING.md)
 - Admin Safe readiness: [`ADMIN_SAFE_READINESS_PLAN.md`](./ADMIN_SAFE_READINESS_PLAN.md)
+- Timelock readiness: [`TIMELOCK_READINESS_PLAN.md`](./TIMELOCK_READINESS_PLAN.md)
 - Early-adopter snapshot: [`EARLY_ADOPTER_SNAPSHOT.md`](./EARLY_ADOPTER_SNAPSHOT.md)
 - Safe / Timelock / handoff ceremony: [`HANDOFF_CEREMONY_PLAN.md`](./HANDOFF_CEREMONY_PLAN.md)
 - Deployment preparation runbook: [`DEPLOYMENT_RUNBOOK.md`](./DEPLOYMENT_RUNBOOK.md)

--- a/docs/mainnet/DEPLOYMENT_RUNBOOK.md
+++ b/docs/mainnet/DEPLOYMENT_RUNBOOK.md
@@ -6,6 +6,8 @@ The finalized launch authority model and unresolved administration blockers are 
 
 The future Safe / Timelock / deployer-revocation ceremony and its read-only verification inputs are documented in [`HANDOFF_CEREMONY_PLAN.md`](./HANDOFF_CEREMONY_PLAN.md).
 
+The Timelock input register, OpenZeppelin version behavior, future dry-run ceremony, and read-only checker are documented in [`TIMELOCK_READINESS_PLAN.md`](./TIMELOCK_READINESS_PLAN.md). Timelock deployment is the next authority blocker; it has not occurred, its address remains `TBD`, and mainnet remains **NO-GO**.
+
 Deploy-grade RPC acceptance and Blockscout verification blockers are tracked in [`DEPLOY_INFRA_READINESS.md`](./DEPLOY_INFRA_READINESS.md).
 
 Mainnet indexer/subgraph inputs, event coverage, and frontend readiness gates are tracked in [`INDEXER_SUBGRAPH_PLAN.md`](./INDEXER_SUBGRAPH_PLAN.md).
@@ -20,6 +22,7 @@ Arc mainnet target: chain ID `5042`, deploy-grade RPC still to be finalized (the
 
 1. Confirm a separately approved deployer and treasury configuration; never place credentials in source.
 2. Run `npx hardhat run scripts/preflight-arc-mainnet.js --network arc_mainnet` and confirm `eth_chainId`, USDC bytecode, `symbol() == USDC`, and `decimals() == 6`.
+   After a separately approved future Timelock deployment, run `node scripts/mainnet/check-timelock-config.js` with the final reviewed inputs and require its read-only PASS before any protocol deployment or handoff. It is not currently runnable because the Timelock address is `TBD`.
 3. Set `USDC_ADDRESS` explicitly. `scripts/v3/deployV3.js` refuses to deploy MockUSDC on non-local networks.
 4. To include early-adopter preparation, set only `DEPLOY_EARLY_ADOPTER_DISCOUNT_REGISTRY=true`. The script validates the version-controlled finalized manifest before any write, deploys exactly one shared registry from its campaign ID and snapshot block, authorizes both controllers, and leaves the root unset, unfrozen, and inactive. Any supplied campaign fact must exactly match the manifest.
 5. The future `arc_mainnet` deployment path configures its newly deployed oracle with p1..p5 = 100/50/25/15/5 USDC and immediately verifies every read. Independently validate it with `scripts/check-mainnet-prices.js` before launch. This preparation task did not execute that path or call `setPrices` on any network.

--- a/docs/mainnet/FOCUSED_SECURITY_REVIEW.md
+++ b/docs/mainnet/FOCUSED_SECURITY_REVIEW.md
@@ -12,6 +12,8 @@ Proof delivery preparation is tracked in [`PROOF_DELIVERY_PLAN.md`](./PROOF_DELI
 
 The consolidated launch inputs and Go/No-Go matrix are tracked in [`MAINNET_LAUNCH_INPUTS.md`](./MAINNET_LAUNCH_INPUTS.md).
 
+Timelock readiness and the future read-only configuration checker are tracked in [`TIMELOCK_READINESS_PLAN.md`](./TIMELOCK_READINESS_PLAN.md). Timelock deployment is the next authority blocker; it is not deployed, its address remains `TBD`, and mainnet remains **NO-GO**.
+
 Remediation status: FSR-02 and FSR-06 are addressed by the Aşama 5A tooling guards. FSR-01 is partially addressed by the verified mainnet 2-of-3 Admin Safe and a fail-closed read-only handoff assertion; Timelock deployment, handoff, and deployer revocation remain unresolved. FSR-04 is partially addressed by Aşama 6A reusable DiscountRegistry ABI/schema/mapping coverage; final address/start-block wiring, deployment, sync, and health verification remain launch actions and blockers.
 
 This is an **internal focused review**, **not an external audit**. Mainnet deployment remains blocked until the blockers listed below are resolved and independently rechecked. No deployment, Arc on-chain write, signing, ownership transfer, role change, price update, Merkle-root update, campaign activation, production frontend switch, staging, commit, or push was performed by this review.
@@ -44,7 +46,7 @@ Deployment remains blocked by incomplete launch administration and infrastructur
 - **Affected:** `scripts/v3/deployV3.js`, `docs/mainnet/ADMIN_OWNERSHIP_PLAN.md`, `docs/mainnet/DEPLOYMENT_RUNBOOK.md`
 - **Description:** The approved 2-of-3 Admin Safe `0xFd48189D3Feb99a5cC6fcC6896744DAa73F3BF72` is created and its exact owner set, threshold, chain, bytecode, and address separation are read-only verified. The Timelock and protocol contract addresses remain `TBD`, the Timelock is not deployed, and `deployV3.js` initializes owners/admin roles to the deployer without performing or verifying the final handoff/revocation sequence.
 - **Impact:** Running the current deploy script alone would leave the deployer with critical protocol authority and would not produce the approved launch state.
-- **Recommended fix:** Finalize and independently verify Safe owners/threshold/address and Timelock configuration; implement a separately reviewed handoff procedure or script with explicit role grants, ownership transfers, deployer revocations/renunciations, and final read-only assertions for every component. Treat deployment and handoff as one incomplete launch operation until all assertions pass.
+- **Recommended fix:** Finalize and independently verify Safe owners/threshold/address and Timelock configuration; after a future approved Timelock deployment, require `scripts/mainnet/check-timelock-config.js` PASS; implement a separately reviewed handoff procedure or script with explicit role grants, ownership transfers, deployer revocations/renunciations, and final read-only assertions for every component. Treat deployment and handoff as one incomplete launch operation until all assertions pass.
 - **Code change required:** Yes, or a dedicated reviewed handoff/verification script.
 - **Docs-only fix sufficient:** No.
 - **Blocks Aşama 6:** Yes.

--- a/docs/mainnet/HANDOFF_CEREMONY_PLAN.md
+++ b/docs/mainnet/HANDOFF_CEREMONY_PLAN.md
@@ -9,7 +9,7 @@ Status: operational planning only. This document describes a future ceremony; it
 - The approved launch model is a 2-of-3 Admin Safe, a 48-hour `TimelockController`, the deployer wallet as the launch treasury recipient, and the Admin Safe as emergency pause authority.
 - The deployer EOA is limited to deployment and bootstrap. After handoff it must retain no protocol authority and may remain only the treasury recipient if that remains the final reviewed launch choice.
 
-The consolidated launch inputs and Go/No-Go matrix are tracked in [`MAINNET_LAUNCH_INPUTS.md`](./MAINNET_LAUNCH_INPUTS.md). Safe creation inputs and read-only validation gates are tracked in [`ADMIN_SAFE_READINESS_PLAN.md`](./ADMIN_SAFE_READINESS_PLAN.md).
+The consolidated launch inputs and Go/No-Go matrix are tracked in [`MAINNET_LAUNCH_INPUTS.md`](./MAINNET_LAUNCH_INPUTS.md). Safe creation inputs and read-only validation gates are tracked in [`ADMIN_SAFE_READINESS_PLAN.md`](./ADMIN_SAFE_READINESS_PLAN.md). Timelock inputs, exact version behavior, and future read-only checks are tracked in [`TIMELOCK_READINESS_PLAN.md`](./TIMELOCK_READINESS_PLAN.md); Timelock deployment is the next authority blocker and remains unexecuted.
 
 ## Required addresses checklist
 
@@ -74,6 +74,8 @@ The following is a numbered dry-run plan for a future ceremony. Every address, r
 18. Set each controller's treasury recipient to the deployer wallet if that remains the final launch choice.
 19. Verify that the deployer has no protocol authority after handoff and remains only the treasury recipient if that launch choice is retained.
 20. Run the read-only `scripts/mainnet/assert-admin-handoff.js` assertion and require its PASS result.
+
+Before protocol deployment or handoff, a future approved Timelock deployment must be followed by `node scripts/mainnet/check-timelock-config.js` with independently reviewed final inputs. The Timelock address remains `TBD`, so this checker is not currently runnable against mainnet.
 
 Deployment and handoff remain one incomplete launch operation until all required final-state reads and the assertion script pass.
 
@@ -177,8 +179,10 @@ Arc mainnet is not ready to deploy while any blocker remains open. Completing th
 
 - Authority model: [`ADMIN_OWNERSHIP_PLAN.md`](./ADMIN_OWNERSHIP_PLAN.md)
 - Admin Safe readiness: [`ADMIN_SAFE_READINESS_PLAN.md`](./ADMIN_SAFE_READINESS_PLAN.md)
+- Timelock readiness: [`TIMELOCK_READINESS_PLAN.md`](./TIMELOCK_READINESS_PLAN.md)
 - Deployment preparation: [`DEPLOYMENT_RUNBOOK.md`](./DEPLOYMENT_RUNBOOK.md)
 - Launch checks: [`SECURITY_CHECKLIST.md`](./SECURITY_CHECKLIST.md)
 - Focused review: [`FOCUSED_SECURITY_REVIEW.md`](./FOCUSED_SECURITY_REVIEW.md)
 - Read-only handoff assertion: [`../../scripts/mainnet/assert-admin-handoff.js`](../../scripts/mainnet/assert-admin-handoff.js)
 - Read-only Safe configuration check: [`../../scripts/mainnet/check-safe-config.js`](../../scripts/mainnet/check-safe-config.js)
+- Future read-only Timelock configuration check: [`../../scripts/mainnet/check-timelock-config.js`](../../scripts/mainnet/check-timelock-config.js)

--- a/docs/mainnet/MAINNET_LAUNCH_INPUTS.md
+++ b/docs/mainnet/MAINNET_LAUNCH_INPUTS.md
@@ -11,6 +11,7 @@ Status: input register and readiness planning only. This document is not launch 
 - Known network facts are Arc mainnet chain ID `5042` and USDC `0x3600000000000000000000000000000000000000`, symbol `USDC`, decimals `6`.
 - Final pricing is 1/2/3/4/5+ characters at 100/50/25/15/5 USDC per year.
 - The finalized early-adopter input is campaign `ARCNS_TESTNET_V3_EARLY_ADOPTER_2026_V1`, campaign bytes32 `0xae3c7462e46cc76b3e0349e7d211264ada95257da9d9d7a797abed70b7eb83e3`, snapshot block `54933646`, snapshot block hash `0x0a450d7fb8055de409084ddb9942f31431aa017a3b3241c4eb8e2e655b8c024d`, Merkle root `0xf18c50fa221162f76d0b88f21aa26e4211c5a77ee72d4dd58240a40406f38d9e`, and 849 eligible wallets. These finalized data inputs are not evidence of any mainnet root operation or activation.
+- Timelock readiness and future read-only validation are tracked in [`TIMELOCK_READINESS_PLAN.md`](./TIMELOCK_READINESS_PLAN.md). The Timelock is the next authority blocker; it is not deployed, its address remains `TBD`, and mainnet remains **NO-GO**.
 
 ## B. Required pre-deployment inputs
 
@@ -114,6 +115,7 @@ Commands are recorded for future reviewed use. Environment values must be suppli
 | `npx hardhat run scripts/preflight-arc-mainnet.js --network arc_mainnet` | Assert chain `5042`, latest block, and known USDC bytecode/symbol/decimals | Configured `arc_mainnet` read provider, normally via transient `ARC_MAINNET_RPC_URL` | Read-only network calls | Provider evaluation and final pre-deployment preflight only | Conditional for read-only fallback; not evidence of deploy-grade approval |
 | `node scripts/mainnet/validate-discount-proof-artifact.js` | Validate finalized artifact metadata, count, and every Merkle proof | Version-controlled finalized snapshot and bundled proof artifact; no env, signer, or RPC | Read-only, local and network-free | Any review/CI context | Yes |
 | `node scripts/mainnet/check-safe-config.js` | Validate Safe chain, bytecode, exact owner set, threshold, and separation from owner EOAs | `SAFE_RPC_URL`, `EXPECTED_CHAIN_ID=5042`, verified Safe address, approved owners, and threshold `2`; Radar is read-only/testing only | Read-only network calls; no signer | Passed against the verified mainnet Safe | PASS; deploy-grade RPC remains TBD |
+| `node scripts/mainnet/check-timelock-config.js` | Validate Timelock chain, bytecode, delay, role constants, Safe roles, self-administration, and optional deployer-admin absence | Future deploy-grade/read provider, `EXPECTED_CHAIN_ID=5042`, final Timelock address, `EXPECTED_MIN_DELAY=172800`, verified Admin Safe, and optional deployer | Read-only network calls; no signer | Only after a future approved Timelock deployment | No; Timelock address is `TBD` |
 | `npx hardhat run scripts/mainnet/assert-admin-handoff.js --network arc_mainnet` | Assert configured owners, roles, treasury, bytecode, and deployer revocation | Final expected Safe, Timelock, treasury, deployer, and all contract addresses, or reviewed artifact path; read provider | Read-only network calls | Only after final deployment and handoff, before public launch | No; final addresses/deployment/handoff are missing |
 | `npx hardhat run scripts/mainnet/discount-set-root.js --network arc_mainnet` | Set only the finalized DiscountRegistry Merkle root after state/owner guards | `CONFIRM_MAINNET_WRITE=YES`, final registry and expected owner, Arc mainnet provider and signer; canonical snapshot | **Write-capable; signs and submits a transaction** | Only in a separately approved post-deployment ceremony after verification and handoff prerequisites | No; forbidden in this task and prerequisites are incomplete |
 | `npx hardhat run scripts/mainnet/discount-freeze-root.js --network arc_mainnet` | Irreversibly freeze the finalized root after exact read-back guards | `CONFIRM_MAINNET_WRITE=YES`, final registry and expected owner, Arc mainnet provider and signer; exact root already set | **Write-capable and irreversible; signs and submits a transaction** | Only in a separate independently reviewed freeze ceremony | No; forbidden in this task and root is not set |
@@ -188,6 +190,7 @@ The read-only handoff assertion has documented coverage limits: Safe owners/thre
 
 - Deployment runbook: [`DEPLOYMENT_RUNBOOK.md`](./DEPLOYMENT_RUNBOOK.md)
 - Admin Safe readiness: [`ADMIN_SAFE_READINESS_PLAN.md`](./ADMIN_SAFE_READINESS_PLAN.md)
+- Timelock readiness: [`TIMELOCK_READINESS_PLAN.md`](./TIMELOCK_READINESS_PLAN.md)
 - Authority model: [`ADMIN_OWNERSHIP_PLAN.md`](./ADMIN_OWNERSHIP_PLAN.md)
 - Handoff ceremony: [`HANDOFF_CEREMONY_PLAN.md`](./HANDOFF_CEREMONY_PLAN.md)
 - Infrastructure readiness: [`DEPLOY_INFRA_READINESS.md`](./DEPLOY_INFRA_READINESS.md)

--- a/docs/mainnet/SECURITY_CHECKLIST.md
+++ b/docs/mainnet/SECURITY_CHECKLIST.md
@@ -12,8 +12,11 @@ Consolidated launch inputs and Go/No-Go readiness: [`MAINNET_LAUNCH_INPUTS.md`](
 
 Admin Safe creation and read-only validation readiness: [`ADMIN_SAFE_READINESS_PLAN.md`](./ADMIN_SAFE_READINESS_PLAN.md).
 
+Timelock readiness and future read-only configuration validation: [`TIMELOCK_READINESS_PLAN.md`](./TIMELOCK_READINESS_PLAN.md).
+
 - [ ] Confirm every ownership, admin, upgrade, pause, treasury, and deployer-revocation item in [`ADMIN_OWNERSHIP_PLAN.md`](./ADMIN_OWNERSHIP_PLAN.md).
 - [x] Confirm the Admin Safe `0xFd48189D3Feb99a5cC6fcC6896744DAa73F3BF72` is a separate Arc mainnet contract, not the deployer or an owner EOA; the read-only `scripts/mainnet/check-safe-config.js` returned `PASS` for the exact owner set and threshold `2`.
+- [ ] After a future approved Timelock deployment, run read-only `scripts/mainnet/check-timelock-config.js` and require PASS for chain `5042`, bytecode, `172800` delay, Safe proposer/executor/canceller roles, self-administration, and deployer-admin absence. The Timelock address remains `TBD`.
 - [ ] Execute and verify the separately reviewed future ceremony in [`HANDOFF_CEREMONY_PLAN.md`](./HANDOFF_CEREMONY_PLAN.md) before launch.
 - [ ] Confirm standard oracle reads are 100/50/25/15/5 USDC in p1..p5 order.
 - [ ] Confirm normal `register()` and `renew()` remain the standard paths.
@@ -36,6 +39,6 @@ Admin Safe creation and read-only validation readiness: [`ADMIN_SAFE_READINESS_P
 - [ ] Replace the dormant DiscountRegistry template with reviewed concrete data-source wiring after the final address and exact start block are available.
 - [ ] Deploy, fully sync, and health-check the reviewed mainnet subgraph before frontend cutover.
 
-Safe creation/configuration verification is complete. Timelock deployment, authority handoff, deployer revocation, deploy-grade RPC selection, Blockscout verification, contract deployment, final DiscountRegistry address/start-block wiring, mainnet indexer/subgraph deployment and sync, root/freeze/activation, final review, active discount integration, and frontend cutover remain unresolved launch blockers. The implemented handler/schema preparation and inactive static proof helper are not evidence of a deployed subgraph, usable discount, or frontend readiness. The production frontend remains testnet-bound. This checklist is not mainnet deployment approval.
+Safe creation/configuration verification is complete. Timelock deployment is the next authority blocker; its address remains `TBD`. Authority handoff, deployer revocation, deploy-grade RPC selection, Blockscout verification, contract deployment, final DiscountRegistry address/start-block wiring, mainnet indexer/subgraph deployment and sync, root/freeze/activation, final review, active discount integration, and frontend cutover remain unresolved launch blockers. The implemented handler/schema preparation and inactive static proof helper are not evidence of a deployed subgraph, usable discount, or frontend readiness. The production frontend remains testnet-bound, and mainnet remains **NO-GO**. This checklist is not mainnet deployment approval.
 
 No deploy/push/on-chain action was performed in this phase.

--- a/docs/mainnet/TIMELOCK_READINESS_PLAN.md
+++ b/docs/mainnet/TIMELOCK_READINESS_PLAN.md
@@ -1,0 +1,103 @@
+# ArcNS Mainnet Timelock Readiness Plan (Aşama 7C)
+
+Status: readiness documentation and read-only tooling preparation only. This is not deployment approval.
+
+## A. Executive summary
+
+- This is a Timelock readiness plan, not a deployment approval.
+- The mainnet Timelock remains not deployed, and its address remains `TBD`.
+- Deployment must wait for explicit operator approval and a finalized deploy-grade RPC. Radar is read-only/testing infrastructure only and must not be treated as deploy-grade RPC.
+- The verified Admin Safe `0xFd48189D3Feb99a5cC6fcC6896744DAa73F3BF72` will be proposer, executor, and canceller.
+- ArcNS mainnet launch remains **NO-GO**.
+
+## B. Timelock input table
+
+`TBD` is a blocker. No address, transaction, block, URL, operator input, or artifact is inferred from testnet or invented.
+
+| Input | Required value | Status | Notes |
+|---|---|---|---|
+| Chain | Arc mainnet | Known | Deployment provider must independently return chain ID `5042`. |
+| Chain ID | `5042` | Known | Required checker input. |
+| Admin Safe | `0xFd48189D3Feb99a5cC6fcC6896744DAa73F3BF72` | PASS; read-only verified | Exact 2-of-3 configuration is recorded in [`ADMIN_SAFE_READINESS_PLAN.md`](./ADMIN_SAFE_READINESS_PLAN.md). |
+| Timelock contract type | OpenZeppelin `TimelockController` via `ArcNSTimelock` wrapper | Prepared; deployment pending | The wrapper adds no logic. Installed OpenZeppelin version is `5.6.1`. |
+| `minDelay` | `172800` seconds | Approved input; deployed read-back pending | Equivalent to 48 hours. |
+| Proposer | Admin Safe (`0xFd48189D3Feb99a5cC6fcC6896744DAa73F3BF72`) | Approved input; deployment pending | Must hold `PROPOSER_ROLE`. |
+| Executor | Admin Safe (`0xFd48189D3Feb99a5cC6fcC6896744DAa73F3BF72`) | Approved input; deployment pending | Must hold `EXECUTOR_ROLE`; do not configure an open executor without explicit review. |
+| Canceller | Admin Safe (`0xFd48189D3Feb99a5cC6fcC6896744DAa73F3BF72`) | Approved input; deployment pending | OpenZeppelin v5 grants `CANCELLER_ROLE` to constructor proposers. |
+| Deployer | `TBD` | Blocked | Confirm exact deployment operator and funding during the future ceremony. |
+| Deploy-grade RPC | `TBD` | Blocked | Radar must not be promoted from read-only/testing use. |
+| Timelock address | `TBD` | Blocked | Record only after deployment and read-only verification. |
+| Deployment tx hash | `TBD` | Blocked | Do not infer from any testnet deployment. |
+| Deployment block | `TBD` | Blocked | Record from the successful receipt. |
+| Deployment block hash | `TBD` | Blocked | Reconcile against the recorded deployment block. |
+| Verification URL | `TBD` | Blocked | Record only after successful reviewed verification submission in a later phase. |
+| Deployment artifact path | `TBD` | Blocked | No deployment artifact is created or modified in this phase. |
+| Read-only verification status | `TBD` | Blocked | Future `check-timelock-config.js` run must return `PASS`. |
+
+## C. Role model
+
+- The Admin Safe remains the operational admin authority.
+- The Timelock should hold upgrade authority after the separately reviewed handoff.
+- Timelock proposer, executor, and canceller should be the verified Admin Safe.
+- The deployer must not retain Timelock admin authority after final setup.
+- With the installed OpenZeppelin Contracts `5.6.1`, Timelock administration uses `DEFAULT_ADMIN_ROLE` (`bytes32(0)`), not a `TIMELOCK_ADMIN_ROLE()` getter. The constructor grants this role to the Timelock itself and grants it to an optional non-zero `admin`. The intended final configuration is self-administration without a deployer bypass.
+- If the exact deployed OpenZeppelin version or deployment script behavior differs, the Timelock must be self-administered or otherwise configured so no deployer bypass exists. Any deviation requires explicit review before deployment.
+
+## D. Future deployment ceremony
+
+This is a dry-run sequence only. Do not deploy from this document.
+
+1. Confirm a clean repository and finalized deployment branch.
+2. Confirm deploy-grade RPC.
+3. Confirm deployer wallet and funding without recording secrets.
+4. Confirm the Admin Safe address and a read-only Safe checker `PASS`.
+5. Confirm Timelock constructor arguments, including `172800`, the Admin Safe proposer/executor arrays, and the reviewed admin argument.
+6. Run static and syntax checks.
+7. Run a dry-run or simulation if an independently reviewed non-broadcast path is available.
+8. Deploy Timelock only after explicit operator approval.
+9. Record the Timelock address, transaction, block, block hash, constructor arguments, and verification URL.
+10. Run the read-only Timelock configuration checker.
+11. Only after Timelock verification, proceed to mainnet protocol contract deployment and handoff planning.
+
+The existing `scripts/v3/deployTimelock.js` is testnet-oriented and write-capable. It obtains a signer, deploys a contract, can sign and execute Safe transactions, grants and revokes roles, and writes a deployment artifact. It must not be run on mainnet in this phase and is not approved as a reusable mainnet deployment ceremony without separate review and adaptation.
+
+## E. Future read-only validation checklist
+
+- [ ] Provider chain ID is `5042`.
+- [ ] Timelock address has non-empty bytecode.
+- [ ] `getMinDelay()` returns `172800`.
+- [ ] Admin Safe has `PROPOSER_ROLE`.
+- [ ] Admin Safe has `EXECUTOR_ROLE`.
+- [ ] Admin Safe has `CANCELLER_ROLE`.
+- [ ] Deployer does not retain bypass or admin authority after final setup.
+- [ ] Timelock roles align with the exact OpenZeppelin version behavior; for v5.6.1, `DEFAULT_ADMIN_ROLE` is held by the Timelock itself and no external bootstrap admin remains.
+- [ ] Timelock address is not equal to the Admin Safe or any owner EOA.
+- [ ] Deployment receipt status is `1`.
+- [ ] Deployment block and block hash are recorded and reconciled.
+
+[`../../scripts/mainnet/check-timelock-config.js`](../../scripts/mainnet/check-timelock-config.js) is a future read-only checker for chain, bytecode, delay, role constants, Safe role membership, self-administration, address separation, and optional deployer-admin absence. It uses no signer, calls no write method, writes no files, and disables JSON-RPC batching. A PASS is necessary but does not replace receipt, block/hash, constructor-argument, explorer, owner-EOA separation, and operator review.
+
+## F. Relationship to Safe
+
+- The Safe is created and read-only verified with the exact three owners and threshold `2`.
+- Timelock deployment depends on the verified Safe address.
+- The Safe will schedule, execute, and cancel delayed upgrade operations through the Timelock.
+- The Safe will still hold immediate emergency pause and operational roles where intentionally planned.
+- Do not change the Safe owner set or threshold in this phase.
+
+## G. Relationship to launch
+
+Timelock deployment alone does not make mainnet ready. Remaining blockers after a future Timelock deployment include protocol contract deployment, role and ownership handoff, deployer revocation, contract verification, indexer deployment and sync, frontend cutover, discount lifecycle operations, monitoring, rollback preparation, and explicit final approval.
+
+The Timelock is the next unresolved authority blocker, but completion of this readiness plan does not resolve that blocker. Mainnet deployment and launch remain **NO-GO**.
+
+## H. Non-goals
+
+- This document does not deploy Timelock.
+- This document does not deploy protocol contracts.
+- This document does not sign or submit transactions.
+- This document does not call write functions.
+- This document does not transfer ownership or roles.
+- This document does not grant or revoke roles.
+- This document does not approve launch.
+- This document does not create or modify a Safe, modify environment values or secrets, create deployment artifacts, submit contract verification, deploy a frontend or subgraph, switch production to mainnet, or enable discount UI.

--- a/scripts/mainnet/check-timelock-config.js
+++ b/scripts/mainnet/check-timelock-config.js
@@ -1,0 +1,168 @@
+"use strict";
+
+const { ethers } = require("ethers");
+
+const TIMELOCK_ABI = [
+  "function getMinDelay() view returns (uint256)",
+  "function hasRole(bytes32 role,address account) view returns (bool)",
+  "function PROPOSER_ROLE() view returns (bytes32)",
+  "function EXECUTOR_ROLE() view returns (bytes32)",
+  "function CANCELLER_ROLE() view returns (bytes32)",
+];
+const REQUIRED_ENV = [
+  "TIMELOCK_RPC_URL",
+  "EXPECTED_CHAIN_ID",
+  "TIMELOCK_ADDRESS",
+  "EXPECTED_MIN_DELAY",
+  "EXPECTED_ADMIN_SAFE",
+];
+const PLACEHOLDER_PATTERN = /(?:^|[\W_])(?:tbd|todo|null|undefined|placeholder|changeme|replace[_-]?me)(?:$|[\W_])|<[^>]*>/i;
+const ROLE_HASHES = {
+  PROPOSER_ROLE: ethers.id("PROPOSER_ROLE"),
+  EXECUTOR_ROLE: ethers.id("EXECUTOR_ROLE"),
+  CANCELLER_ROLE: ethers.id("CANCELLER_ROLE"),
+  // OpenZeppelin Contracts v5.6.1 uses DEFAULT_ADMIN_ROLE for Timelock administration.
+  TIMELOCK_ADMIN_ROLE: ethers.ZeroHash,
+};
+
+function requiredValue(env, name) {
+  const value = String(env[name] || "").trim();
+  if (!value || PLACEHOLDER_PATTERN.test(value)) {
+    throw new Error(`${name} is required and must not be empty or a placeholder`);
+  }
+  return value;
+}
+
+function nonNegativeInteger(value, name) {
+  if (!/^\d+$/.test(value)) throw new Error(`${name} must be a non-negative integer`);
+  return BigInt(value);
+}
+
+function positiveInteger(value, name) {
+  const parsed = nonNegativeInteger(value, name);
+  if (parsed < 1n) throw new Error(`${name} must be a positive integer`);
+  return parsed;
+}
+
+function checkedAddress(value, name) {
+  try {
+    const address = ethers.getAddress(value);
+    if (address === ethers.ZeroAddress) throw new Error("zero address");
+    return address;
+  } catch (_) {
+    throw new Error(`${name} must be a valid non-zero address`);
+  }
+}
+
+function maskRpcUrl(value) {
+  try {
+    const url = new URL(value);
+    return `${url.protocol}//${url.host}/***`;
+  } catch (_) {
+    return "<masked-invalid-url>";
+  }
+}
+
+function loadConfig(env = process.env) {
+  for (const name of REQUIRED_ENV) requiredValue(env, name);
+
+  const rpcUrl = requiredValue(env, "TIMELOCK_RPC_URL");
+  let parsedRpc;
+  try {
+    parsedRpc = new URL(rpcUrl);
+  } catch (_) {
+    throw new Error("TIMELOCK_RPC_URL must be a valid HTTP(S) URL");
+  }
+  if (!/^https?:$/.test(parsedRpc.protocol)) {
+    throw new Error("TIMELOCK_RPC_URL must use HTTP or HTTPS");
+  }
+
+  const allowValue = String(env.ALLOW_DEPLOYER_TIMELOCK_ADMIN || "0").trim();
+  if (!/^[01]$/.test(allowValue)) {
+    throw new Error("ALLOW_DEPLOYER_TIMELOCK_ADMIN must be 0 or 1");
+  }
+
+  const timelockAddress = checkedAddress(requiredValue(env, "TIMELOCK_ADDRESS"), "TIMELOCK_ADDRESS");
+  const adminSafe = checkedAddress(requiredValue(env, "EXPECTED_ADMIN_SAFE"), "EXPECTED_ADMIN_SAFE");
+  if (timelockAddress === adminSafe) {
+    throw new Error("TIMELOCK_ADDRESS must not equal EXPECTED_ADMIN_SAFE");
+  }
+
+  let deployer;
+  if (String(env.DEPLOYER_ADDRESS || "").trim()) {
+    const rawDeployer = requiredValue(env, "DEPLOYER_ADDRESS");
+    deployer = checkedAddress(rawDeployer, "DEPLOYER_ADDRESS");
+    if (deployer === timelockAddress) throw new Error("DEPLOYER_ADDRESS must not equal TIMELOCK_ADDRESS");
+  }
+
+  return {
+    rpcUrl,
+    expectedChainId: positiveInteger(requiredValue(env, "EXPECTED_CHAIN_ID"), "EXPECTED_CHAIN_ID"),
+    timelockAddress,
+    expectedMinDelay: nonNegativeInteger(requiredValue(env, "EXPECTED_MIN_DELAY"), "EXPECTED_MIN_DELAY"),
+    adminSafe,
+    deployer,
+    allowDeployerTimelockAdmin: allowValue === "1",
+  };
+}
+
+async function main() {
+  const config = loadConfig();
+  console.log(`RPC: ${maskRpcUrl(config.rpcUrl)}`);
+  console.log("Timelock admin role model: OpenZeppelin v5 DEFAULT_ADMIN_ROLE (bytes32(0)); no TIMELOCK_ADMIN_ROLE() getter.");
+
+  const provider = new ethers.JsonRpcProvider(config.rpcUrl, config.expectedChainId, { batchMaxCount: 1 });
+  const network = await provider.getNetwork();
+  if (network.chainId !== config.expectedChainId) {
+    throw new Error(`Chain ID mismatch: expected ${config.expectedChainId}, received ${network.chainId}`);
+  }
+
+  const code = await provider.getCode(config.timelockAddress);
+  if (code === "0x") throw new Error("TIMELOCK_ADDRESS has no bytecode");
+
+  const timelock = new ethers.Contract(config.timelockAddress, TIMELOCK_ABI, provider);
+  const [minDelay, proposerRole, executorRole, cancellerRole] = await Promise.all([
+    timelock.getMinDelay(),
+    timelock.PROPOSER_ROLE(),
+    timelock.EXECUTOR_ROLE(),
+    timelock.CANCELLER_ROLE(),
+  ]);
+
+  if (minDelay !== config.expectedMinDelay) {
+    throw new Error(`Minimum delay mismatch: expected ${config.expectedMinDelay}, received ${minDelay}`);
+  }
+  for (const [name, actual] of Object.entries({ PROPOSER_ROLE: proposerRole, EXECUTOR_ROLE: executorRole, CANCELLER_ROLE: cancellerRole })) {
+    if (actual !== ROLE_HASHES[name]) throw new Error(`${name} hash mismatch`);
+  }
+
+  const [safeIsProposer, safeIsExecutor, safeIsCanceller, timelockIsAdmin, safeIsAdmin] = await Promise.all([
+    timelock.hasRole(proposerRole, config.adminSafe),
+    timelock.hasRole(executorRole, config.adminSafe),
+    timelock.hasRole(cancellerRole, config.adminSafe),
+    timelock.hasRole(ROLE_HASHES.TIMELOCK_ADMIN_ROLE, config.timelockAddress),
+    timelock.hasRole(ROLE_HASHES.TIMELOCK_ADMIN_ROLE, config.adminSafe),
+  ]);
+  if (!safeIsProposer) throw new Error("EXPECTED_ADMIN_SAFE does not hold PROPOSER_ROLE");
+  if (!safeIsExecutor) throw new Error("EXPECTED_ADMIN_SAFE does not hold EXECUTOR_ROLE");
+  if (!safeIsCanceller) throw new Error("EXPECTED_ADMIN_SAFE does not hold CANCELLER_ROLE");
+  if (!timelockIsAdmin) throw new Error("Timelock is not self-administered through DEFAULT_ADMIN_ROLE");
+  if (safeIsAdmin) throw new Error("EXPECTED_ADMIN_SAFE unexpectedly retains Timelock DEFAULT_ADMIN_ROLE bypass authority");
+
+  if (config.deployer) {
+    const deployerIsAdmin = await timelock.hasRole(ROLE_HASHES.TIMELOCK_ADMIN_ROLE, config.deployer);
+    if (deployerIsAdmin && !config.allowDeployerTimelockAdmin) {
+      throw new Error("DEPLOYER_ADDRESS retains Timelock DEFAULT_ADMIN_ROLE; set ALLOW_DEPLOYER_TIMELOCK_ADMIN=1 only for an explicitly reviewed exception");
+    }
+  }
+
+  console.log(`PASS: Timelock ${config.timelockAddress} has bytecode, delay ${minDelay}, expected Safe roles, self-administration, and chain ID ${network.chainId} (read-only).`);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(`FAIL: ${error.message.replace(/https?:\/\/[^\s)]+/gi, "<masked-rpc-url>")}`);
+    process.exit(1);
+  });
+}
+
+module.exports = { loadConfig, main, maskRpcUrl, ROLE_HASHES };


### PR DESCRIPTION
This PR adds the ArcNS mainnet Timelock readiness plan and a read-only Timelock configuration checker for Aşama 7C.

Included:
- Adds docs/mainnet/TIMELOCK_READINESS_PLAN.md.
- Adds scripts/mainnet/check-timelock-config.js.
- Updates mainnet launch inputs, handoff ceremony, admin ownership, security checklist, focused review, and deployment runbook docs.
- Records the planned mainnet Timelock model:
  - OpenZeppelin TimelockController through the existing ArcNSTimelock wrapper
  - Chain ID 5042
  - minDelay 172800 seconds
  - proposer/executor/canceller set to the verified Admin Safe
- Documents that the mainnet Timelock address, tx, block, verification URL, and artifact path remain TBD.
- Keeps deploy-grade RPC unresolved.
- Keeps mainnet launch NO-GO.

Checker behavior:
- Fully read-only.
- Uses ethers JsonRpcProvider with batching disabled.
- Uses no signer.
- Submits no transactions.
- Calls no write methods.
- Writes no files.
- Validates chain ID, bytecode, minDelay, role hashes, Safe role membership, self-administration, Safe/admin bypass absence, and optional deployer-admin absence.

Not included:
- No Timelock deployment.
- No contract deployment.
- No frontend deployment.
- No subgraph deployment.
- No live on-chain write.
- No signing.
- No contract verification submission.
- No ownership or role transfer.
- No role grant or revocation.
- No root set/freeze/activation.
- No env, secret, key, API key, wallet material, or deployment artifact changes.

Validation:
- git diff --check passed.
- node --check scripts/mainnet/check-timelock-config.js passed.
- node --check scripts/mainnet/check-safe-config.js passed.
- Restricted terminology scans passed.
- Placeholder negative test passed.

Remaining blockers:
- Timelock deployment and read-only verification.
- Deploy-grade RPC selection and approval.
- Timelock address and deployment evidence.
- Blockscout verification workflow.
- Mainnet protocol contract deployment.
- Ownership/role handoff and deployer revocation.
- Final read-only handoff assertion.
- Indexer/subgraph deployment and health checks.
- Frontend mainnet cutover.
- Discount root set, freeze, and activation ceremonies.
- Monitoring and final explicit launch approval.