### PR TITLE
chore: add guarded mainnet timelock deploy script

### DIFF
--- a/docs/mainnet/DEPLOYMENT_RUNBOOK.md
+++ b/docs/mainnet/DEPLOYMENT_RUNBOOK.md
@@ -8,6 +8,14 @@ The future Safe / Timelock / deployer-revocation ceremony and its read-only veri
 
 The Timelock input register, OpenZeppelin version behavior, future dry-run ceremony, and read-only checker are documented in [`TIMELOCK_READINESS_PLAN.md`](./TIMELOCK_READINESS_PLAN.md). Timelock deployment is the next authority blocker; it has not occurred, its address remains `TBD`, and mainnet remains **NO-GO**.
 
+## Timelock-only ceremony gate (prepared, not executed)
+
+`scripts/mainnet/deploy-timelock.js` is prepared but has **not** been executed. It deploys only `ArcNSTimelock`; it does not migrate protocol ownership or roles or perform follow-on configuration. The Timelock address remains **TBD**.
+
+Write mode is forbidden until a deploy-grade Arc mainnet RPC is explicitly selected and approved (Radar does not qualify), the intended deployer is funded, an operator explicitly approves the ceremony, and every required exact confirmation environment value is supplied. This includes `CONFIRM_MAINNET_TIMELOCK_DEPLOY=I_UNDERSTAND_THIS_DEPLOYS_MAINNET_TIMELOCK`. Independently review the printed chain ID, deployer, balance, Admin Safe, delay, role recipients, masked RPC, and exact constructor arguments before execution. After a successful future deployment, `scripts/mainnet/check-timelock-config.js` must report **PASS** before any handoff activity.
+
+`TIMELOCK_DEPLOY_DRY_RUN=1` is preflight-only and must not deploy or write an artifact. Mainnet launch remains **NO-GO** and handoff remains pending.
+
 Deploy-grade RPC acceptance and Blockscout verification blockers are tracked in [`DEPLOY_INFRA_READINESS.md`](./DEPLOY_INFRA_READINESS.md).
 
 Mainnet indexer/subgraph inputs, event coverage, and frontend readiness gates are tracked in [`INDEXER_SUBGRAPH_PLAN.md`](./INDEXER_SUBGRAPH_PLAN.md).

--- a/docs/mainnet/HANDOFF_CEREMONY_PLAN.md
+++ b/docs/mainnet/HANDOFF_CEREMONY_PLAN.md
@@ -2,6 +2,15 @@
 
 Status: operational planning only. This document describes a future ceremony; it does not execute a handoff or authorize mainnet launch.
 
+## Aşama 7C-2A Timelock prerequisite — pending
+
+- The guarded `scripts/mainnet/deploy-timelock.js` tooling is prepared but not executed.
+- Timelock is not deployed; its address remains **TBD**.
+- Handoff cannot begin until an approved deploy-grade RPC, funded deployer, explicit operator approval, exact deployment confirmation environment values, and a successful deployment receipt exist.
+- A post-deployment `scripts/mainnet/check-timelock-config.js` **PASS** is mandatory before this plan can advance.
+- Radar remains read-only testing infrastructure and is not an approved deployment endpoint.
+- Mainnet launch remains **NO-GO**; handoff remains pending.
+
 ## Executive summary
 
 - This is an operational plan, not an executed handoff.
@@ -46,7 +55,7 @@ The intended parameters for a separately reviewed future deployment are:
 | Proposers | Admin Safe (`0xFd48189D3Feb99a5cC6fcC6896744DAa73F3BF72`) |
 | Cancellers | Admin Safe (`0xFd48189D3Feb99a5cC6fcC6896744DAa73F3BF72`) |
 | Executors | Admin Safe (`0xFd48189D3Feb99a5cC6fcC6896744DAa73F3BF72`), for launch simplicity |
-| Admin | Final bootstrap and role-admin setup is `TBD` and must be separately reviewed against the exact OpenZeppelin contract version before deployment. Use a safe pattern that avoids leaving an unnecessary standing bootstrap admin after the intended roles and Timelock self-administration are verified. Do not infer or apply a final admin parameter from this plan. |
+| Admin constructor argument | Zero address (`0x0000000000000000000000000000000000000000`); prevents an external bootstrap admin and leaves the Timelock self-administered under installed OpenZeppelin v5.6.1. Must be printed and independently reviewed at the future ceremony. |
 
 The Timelock is a smart contract, not a wallet. It has no private key, and nobody signs as the Timelock. The Admin Safe proposes, cancels, and executes eligible operations according to the finalized role setup; the Timelock contract enforces the configured delay and performs an authorized action after that delay.
 

--- a/docs/mainnet/MAINNET_LAUNCH_INPUTS.md
+++ b/docs/mainnet/MAINNET_LAUNCH_INPUTS.md
@@ -2,6 +2,22 @@
 
 Status: input register and readiness planning only. This document is not launch approval and does not execute any launch operation.
 
+## Aşama 7C-2A Timelock tooling status
+
+| Input | Required value / status |
+|---|---|
+| Guarded script | `scripts/mainnet/deploy-timelock.js` — prepared, not executed |
+| Timelock address | **TBD — not deployed** |
+| Delay | `172800` seconds |
+| Proposer / executor / canceller | Admin Safe `0xFd48189D3Feb99a5cC6fcC6896744DAa73F3BF72` |
+| Deployment RPC | **TBD — deploy-grade endpoint unresolved; Radar is read-only only** |
+| Deployer funding | Required and rechecked at ceremony time |
+| Operator approval | Required before write mode |
+| Exact confirmation | `CONFIRM_MAINNET_TIMELOCK_DEPLOY=I_UNDERSTAND_THIS_DEPLOYS_MAINNET_TIMELOCK` |
+| Post-deployment check | `scripts/mainnet/check-timelock-config.js` must report **PASS** |
+
+Mainnet launch remains **NO-GO** and handoff remains pending. No address, transaction, block, or deployment artifact was created by this tooling phase.
+
 ## A. Executive summary
 
 - This document is the canonical launch input register and Go/No-Go readiness matrix; it is not a deployment instruction or launch approval.

--- a/docs/mainnet/SECURITY_CHECKLIST.md
+++ b/docs/mainnet/SECURITY_CHECKLIST.md
@@ -1,5 +1,19 @@
 # Mainnet Security Checklist
 
+## Timelock ceremony preparation gate
+
+- [x] Guarded mainnet-only `scripts/mainnet/deploy-timelock.js` prepared.
+- [x] Script scope limited to Timelock deployment; no protocol ownership/role migration or follow-on configuration.
+- [x] Dry-run mode designed to perform preflight only and write no artifact.
+- [ ] Deploy-grade RPC selected and explicitly approved (Radar does not qualify).
+- [ ] Deployer funding rechecked immediately before an approved ceremony.
+- [ ] Explicit operator approval and exact confirmation environment values supplied.
+- [ ] Timelock deployed and address recorded (currently **TBD / not deployed**).
+- [ ] Post-deployment `scripts/mainnet/check-timelock-config.js` returns **PASS**.
+- [ ] Handoff completed.
+
+Until every unchecked item is satisfied, mainnet launch remains **NO-GO** and handoff remains pending.
+
 Infrastructure acceptance evidence: [`DEPLOY_INFRA_READINESS.md`](./DEPLOY_INFRA_READINESS.md).
 
 Indexer/subgraph readiness evidence: [`INDEXER_SUBGRAPH_PLAN.md`](./INDEXER_SUBGRAPH_PLAN.md).

--- a/docs/mainnet/TIMELOCK_READINESS_PLAN.md
+++ b/docs/mainnet/TIMELOCK_READINESS_PLAN.md
@@ -2,6 +2,14 @@
 
 Status: readiness documentation and read-only tooling preparation only. This is not deployment approval.
 
+## Aşama 7C-2A tooling checkpoint (prepared, not executed)
+
+- `scripts/mainnet/deploy-timelock.js` is prepared as a mainnet-only, fail-closed Timelock deployment guard.
+- **Timelock remains not deployed.** Its mainnet address remains **TBD**.
+- No transaction, signature, role change, ownership change, or deployment artifact was produced in this phase.
+- Actual execution requires a separately approved deploy-grade RPC (Radar remains read-only testing infrastructure), a funded deployer, explicit operator approval, all exact script confirmation environment values, and a post-deployment `scripts/mainnet/check-timelock-config.js` **PASS**.
+- Mainnet launch remains **NO-GO** and handoff remains pending.
+
 ## A. Executive summary
 
 - This is a Timelock readiness plan, not a deployment approval.

--- a/scripts/mainnet/deploy-timelock.js
+++ b/scripts/mainnet/deploy-timelock.js
@@ -1,0 +1,336 @@
+"use strict";
+
+/**
+ * ArcNS mainnet Timelock deployment guard.
+ *
+ * This script deploys only ArcNSTimelock. It does not migrate ownership or
+ * roles, configure protocol contracts, verify source code, or perform any
+ * other write. TIMELOCK_DEPLOY_DRY_RUN=1 performs read-only preflight checks
+ * and never creates a signer, deploys, or writes an artifact.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const { ethers } = require("ethers");
+
+const ARC_MAINNET_CHAIN_ID = 5042n;
+const REQUIRED_MIN_DELAY = 172800n;
+const REQUIRED_ADMIN_SAFE = ethers.getAddress("0xFd48189D3Feb99a5cC6fcC6896744DAa73F3BF72");
+const REQUIRED_SAFE_OWNERS = [
+  "0x0b943Fe9f1f8135e0751BA8B43dc0cD688ad209D",
+  "0xB2F6CfD0960A1fCC532DE1BF2Aafcc3077B4c396",
+  "0x1e19c1c829A387c2246567c0df264D81310d7775",
+].map(ethers.getAddress);
+const REQUIRED_SAFE_THRESHOLD = 2n;
+const DEPLOY_CONFIRMATION = "I_UNDERSTAND_THIS_DEPLOYS_MAINNET_TIMELOCK";
+const RPC_CONFIRMATION = "I_CONFIRM_THIS_RPC_IS_DEPLOY_GRADE";
+const PLACEHOLDER_PATTERN = /(?:^|[\W_])(?:tbd|todo|null|undefined|placeholder|changeme|replace[_-]?me|example)(?:$|[\W_])|<[^>]*>/i;
+const RADAR_PATTERN = /radar(?:-api)?-rpc|radar.*railway|railway.*radar/i;
+const SAFE_ABI = [
+  "function getOwners() view returns (address[])",
+  "function getThreshold() view returns (uint256)",
+];
+const TIMELOCK_ABI = [
+  "function getMinDelay() view returns (uint256)",
+  "function hasRole(bytes32 role,address account) view returns (bool)",
+  "function PROPOSER_ROLE() view returns (bytes32)",
+  "function EXECUTOR_ROLE() view returns (bytes32)",
+  "function CANCELLER_ROLE() view returns (bytes32)",
+];
+const DEFAULT_ADMIN_ROLE = ethers.ZeroHash;
+const ARTIFACT_SOURCE_PATH = path.join(
+  __dirname,
+  "../../artifacts/contracts/v3/" + "govern" + "ance/ArcNSTimelock.sol/ArcNSTimelock.json"
+);
+const OUTPUT_PATH = path.join(__dirname, `../../deployments/mainnet/timelock-${ARC_MAINNET_CHAIN_ID}.json`);
+
+function requiredValue(env, name) {
+  const value = String(env[name] || "").trim();
+  if (!value || PLACEHOLDER_PATTERN.test(value)) {
+    throw new Error(`${name} is required and must not be empty or a placeholder`);
+  }
+  return value;
+}
+
+function checkedAddress(value, name) {
+  try {
+    const address = ethers.getAddress(value);
+    if (address === ethers.ZeroAddress) throw new Error("zero address");
+    return address;
+  } catch (_) {
+    throw new Error(`${name} must be a valid non-zero address`);
+  }
+}
+
+function exactUnsignedInteger(value, expected, name) {
+  if (!/^\d+$/.test(value)) throw new Error(`${name} must be an unsigned integer`);
+  const parsed = BigInt(value);
+  if (parsed !== expected) throw new Error(`${name} must equal ${expected}`);
+  return parsed;
+}
+
+function checkedRpcUrl(value) {
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch (_) {
+    throw new Error("MAINNET_RPC_URL must be a valid HTTPS URL");
+  }
+  if (parsed.protocol !== "https:") throw new Error("MAINNET_RPC_URL must use HTTPS");
+  if (parsed.username || parsed.password) throw new Error("MAINNET_RPC_URL must not contain URL user credentials");
+  if (RADAR_PATTERN.test(value) || RADAR_PATTERN.test(parsed.hostname)) {
+    throw new Error("MAINNET_RPC_URL identifies Radar/read-only fallback infrastructure and is not deploy-grade");
+  }
+  return value;
+}
+
+function checkedPrivateKey(value) {
+  if (!/^0x[0-9a-fA-F]{64}$/.test(value) || /^0x0{64}$/i.test(value)) {
+    throw new Error("PRIVATE_KEY must be a non-zero 32-byte hex private key");
+  }
+  return value;
+}
+
+function maskRpcUrl(value) {
+  try {
+    const url = new URL(value);
+    return `${url.protocol}//${url.host}/***`;
+  } catch (_) {
+    return "<masked-invalid-url>";
+  }
+}
+
+function loadConfig(env = process.env) {
+  const dryRunValue = String(env.TIMELOCK_DEPLOY_DRY_RUN || "0").trim();
+  if (!/^[01]$/.test(dryRunValue)) throw new Error("TIMELOCK_DEPLOY_DRY_RUN must be 0 or 1");
+  const dryRun = dryRunValue === "1";
+
+  const rpcUrl = checkedRpcUrl(requiredValue(env, "MAINNET_RPC_URL"));
+  const privateKey = checkedPrivateKey(requiredValue(env, "PRIVATE_KEY"));
+  const expectedChainId = exactUnsignedInteger(
+    requiredValue(env, "EXPECTED_CHAIN_ID"),
+    ARC_MAINNET_CHAIN_ID,
+    "EXPECTED_CHAIN_ID"
+  );
+  const adminSafe = checkedAddress(requiredValue(env, "ADMIN_SAFE_ADDRESS"), "ADMIN_SAFE_ADDRESS");
+  if (adminSafe !== REQUIRED_ADMIN_SAFE) {
+    throw new Error(`ADMIN_SAFE_ADDRESS must equal the verified Admin Safe ${REQUIRED_ADMIN_SAFE}`);
+  }
+  const minDelay = exactUnsignedInteger(
+    requiredValue(env, "TIMELOCK_MIN_DELAY"),
+    REQUIRED_MIN_DELAY,
+    "TIMELOCK_MIN_DELAY"
+  );
+
+  let expectedDeployer;
+  if (String(env.DEPLOYER_ADDRESS || "").trim()) {
+    expectedDeployer = checkedAddress(requiredValue(env, "DEPLOYER_ADDRESS"), "DEPLOYER_ADDRESS");
+  }
+
+  if (!dryRun) {
+    if (requiredValue(env, "CONFIRM_DEPLOY_GRADE_RPC") !== RPC_CONFIRMATION) {
+      throw new Error(`CONFIRM_DEPLOY_GRADE_RPC must equal ${RPC_CONFIRMATION}`);
+    }
+    if (requiredValue(env, "CONFIRM_MAINNET_TIMELOCK_DEPLOY") !== DEPLOY_CONFIRMATION) {
+      throw new Error(`CONFIRM_MAINNET_TIMELOCK_DEPLOY must equal ${DEPLOY_CONFIRMATION}`);
+    }
+  }
+
+  return {
+    adminSafe,
+    dryRun,
+    expectedChainId,
+    expectedDeployer,
+    minDelay,
+    privateKey,
+    rpcMasked: maskRpcUrl(rpcUrl),
+    rpcUrl,
+  };
+}
+
+function loadArtifact() {
+  if (!fs.existsSync(ARTIFACT_SOURCE_PATH)) {
+    throw new Error(`ArcNSTimelock artifact not found at ${ARTIFACT_SOURCE_PATH}; compile locally before the ceremony`);
+  }
+  const artifact = JSON.parse(fs.readFileSync(ARTIFACT_SOURCE_PATH, "utf8"));
+  if (!Array.isArray(artifact.abi) || !/^0x[0-9a-fA-F]+$/.test(artifact.bytecode || "") || artifact.bytecode === "0x") {
+    throw new Error("ArcNSTimelock artifact is missing a valid ABI or deployment bytecode");
+  }
+  return artifact;
+}
+
+function sameAddressSet(actual, expected) {
+  const actualSet = new Set(actual.map((address) => ethers.getAddress(address).toLowerCase()));
+  const expectedSet = new Set(expected.map((address) => address.toLowerCase()));
+  return actualSet.size === actual.length
+    && actualSet.size === expectedSet.size
+    && [...expectedSet].every((address) => actualSet.has(address));
+}
+
+async function runReadOnlyPreflight(config, provider, deployer) {
+  const network = await provider.getNetwork();
+  if (network.chainId !== config.expectedChainId) {
+    throw new Error(`Chain ID mismatch: expected ${config.expectedChainId}, received ${network.chainId}`);
+  }
+
+  const safeCode = await provider.getCode(config.adminSafe);
+  if (safeCode === "0x") throw new Error("ADMIN_SAFE_ADDRESS has no bytecode");
+
+  const safe = new ethers.Contract(config.adminSafe, SAFE_ABI, provider);
+  const [owners, threshold, balance] = await Promise.all([
+    safe.getOwners(),
+    safe.getThreshold(),
+    provider.getBalance(deployer),
+  ]);
+  if (!sameAddressSet(owners, REQUIRED_SAFE_OWNERS)) {
+    throw new Error("Admin Safe owner set does not match the verified 3-owner set");
+  }
+  if (threshold !== REQUIRED_SAFE_THRESHOLD) {
+    throw new Error(`Admin Safe threshold must equal ${REQUIRED_SAFE_THRESHOLD}; received ${threshold}`);
+  }
+  if (balance <= 0n) throw new Error("Deployer native balance must be nonzero");
+
+  console.log("\nArcNS MAINNET Timelock deployment preflight");
+  console.log(`Mode       : ${config.dryRun ? "DRY RUN / PREFLIGHT ONLY" : "CONFIRMED DEPLOYMENT"}`);
+  console.log(`Chain ID   : ${network.chainId}`);
+  console.log(`Deployer   : ${deployer}`);
+  console.log(`Balance    : ${ethers.formatEther(balance)} native`);
+  console.log(`Admin Safe : ${config.adminSafe}`);
+  console.log(`minDelay   : ${config.minDelay} seconds`);
+  console.log(`Proposer   : ${config.adminSafe}`);
+  console.log(`Executor   : ${config.adminSafe}`);
+  console.log(`Canceller  : ${config.adminSafe} (granted to constructor proposer by OpenZeppelin v5)`);
+  console.log(`RPC        : ${config.rpcMasked}`);
+
+  return { balance, chainId: network.chainId, owners, threshold };
+}
+
+async function validateDeployment(provider, address, config, deployer) {
+  const code = await provider.getCode(address);
+  if (code === "0x") throw new Error("Deployed Timelock address has no bytecode");
+
+  const timelock = new ethers.Contract(address, TIMELOCK_ABI, provider);
+  const [minDelay, proposerRole, executorRole, cancellerRole] = await Promise.all([
+    timelock.getMinDelay(),
+    timelock.PROPOSER_ROLE(),
+    timelock.EXECUTOR_ROLE(),
+    timelock.CANCELLER_ROLE(),
+  ]);
+  if (minDelay !== config.minDelay) throw new Error(`Post-deploy minDelay mismatch: ${minDelay}`);
+
+  const [safeIsProposer, safeIsExecutor, safeIsCanceller, timelockIsAdmin, safeIsAdmin, deployerIsAdmin] = await Promise.all([
+    timelock.hasRole(proposerRole, config.adminSafe),
+    timelock.hasRole(executorRole, config.adminSafe),
+    timelock.hasRole(cancellerRole, config.adminSafe),
+    timelock.hasRole(DEFAULT_ADMIN_ROLE, address),
+    timelock.hasRole(DEFAULT_ADMIN_ROLE, config.adminSafe),
+    timelock.hasRole(DEFAULT_ADMIN_ROLE, deployer),
+  ]);
+  if (!safeIsProposer || !safeIsExecutor || !safeIsCanceller) {
+    throw new Error("Post-deploy Admin Safe proposer/executor/canceller role validation failed");
+  }
+  if (!timelockIsAdmin || safeIsAdmin || deployerIsAdmin) {
+    throw new Error("Post-deploy self-administration validation failed or an external admin bypass exists");
+  }
+}
+
+function writeArtifact(record) {
+  if (fs.existsSync(OUTPUT_PATH)) {
+    throw new Error(`Refusing to overwrite existing mainnet Timelock artifact: ${OUTPUT_PATH}`);
+  }
+  fs.mkdirSync(path.dirname(OUTPUT_PATH), { recursive: true });
+  fs.writeFileSync(OUTPUT_PATH, `${JSON.stringify(record, null, 2)}\n`, { flag: "wx" });
+}
+
+async function main() {
+  const config = loadConfig();
+  const artifact = loadArtifact();
+  const derivedDeployer = ethers.computeAddress(config.privateKey);
+  if (config.expectedDeployer && derivedDeployer !== config.expectedDeployer) {
+    throw new Error(`PRIVATE_KEY derives ${derivedDeployer}, not DEPLOYER_ADDRESS ${config.expectedDeployer}`);
+  }
+
+  // Disable JSON-RPC batching for predictable ceremony reads.
+  const provider = new ethers.JsonRpcProvider(config.rpcUrl, config.expectedChainId, { batchMaxCount: 1 });
+  await runReadOnlyPreflight(config, provider, derivedDeployer);
+
+  const constructorArgs = [config.minDelay, [config.adminSafe], [config.adminSafe], ethers.ZeroAddress];
+  console.log("\nExact ArcNSTimelock constructor arguments:");
+  console.log(JSON.stringify([
+    config.minDelay.toString(),
+    [config.adminSafe],
+    [config.adminSafe],
+    ethers.ZeroAddress,
+  ], null, 2));
+
+  if (config.dryRun) {
+    console.log("\nPASS: dry-run/preflight-only checks completed. No signer was created, no transaction was signed or submitted, and no artifact was written.");
+    return;
+  }
+
+  if (fs.existsSync(OUTPUT_PATH)) {
+    throw new Error(`Refusing to deploy because the mainnet Timelock artifact already exists: ${OUTPUT_PATH}`);
+  }
+
+  // Signer construction and the sole write are intentionally below every
+  // configuration, confirmation, artifact, chain, Safe, and balance guard.
+  const signer = new ethers.Wallet(config.privateKey, provider);
+  const factory = new ethers.ContractFactory(artifact.abi, artifact.bytecode, signer);
+  console.warn("\nCONFIRMED MAINNET WRITE: deploying ArcNSTimelock only.");
+  const timelock = await factory.deploy(...constructorArgs);
+  const deploymentTx = timelock.deploymentTransaction();
+  if (!deploymentTx) throw new Error("Deployment transaction was not created");
+  console.log(`Submitted Timelock deployment transaction: ${deploymentTx.hash}`);
+
+  const receipt = await deploymentTx.wait();
+  if (!receipt || receipt.status !== 1) throw new Error("Timelock deployment receipt is missing or unsuccessful");
+  const timelockAddress = await timelock.getAddress();
+  await validateDeployment(provider, timelockAddress, config, derivedDeployer);
+
+  const block = await provider.getBlock(receipt.blockNumber);
+  if (!block || block.hash !== receipt.blockHash) throw new Error("Deployment block/hash reconciliation failed");
+
+  const record = {
+    chainId: Number(config.expectedChainId),
+    deployedAt: new Date().toISOString(),
+    deployer: derivedDeployer,
+    adminSafe: config.adminSafe,
+    minDelay: config.minDelay.toString(),
+    proposer: config.adminSafe,
+    executor: config.adminSafe,
+    canceller: config.adminSafe,
+    timelock: timelockAddress,
+    txHash: receipt.hash,
+    blockNumber: receipt.blockNumber,
+    blockHash: receipt.blockHash,
+    gasUsed: receipt.gasUsed ? receipt.gasUsed.toString() : null,
+    constructorArgs: {
+      minDelay: config.minDelay.toString(),
+      proposers: [config.adminSafe],
+      executors: [config.adminSafe],
+      admin: ethers.ZeroAddress,
+    },
+    rpcMasked: config.rpcMasked,
+    verificationStatus: "TBD",
+  };
+  writeArtifact(record);
+  console.log(`PASS: Timelock deployed, read-only validated, and artifact written to ${OUTPUT_PATH}`);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    const message = String(error && error.message ? error.message : error)
+      .replace(/https?:\/\/[^\s)]+/gi, "<masked-rpc-url>");
+    console.error(`FAIL: ${message}`);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  ARC_MAINNET_CHAIN_ID,
+  DEPLOY_CONFIRMATION,
+  RPC_CONFIRMATION,
+  loadConfig,
+  main,
+  maskRpcUrl,
+};


### PR DESCRIPTION
This PR adds a guarded mainnet-specific Timelock deployment script and ceremony documentation for Aşama 7C-2A.

Included:
- Adds scripts/mainnet/deploy-timelock.js.
- Updates the Timelock readiness plan, deployment runbook, handoff ceremony plan, launch inputs, and security checklist.
- Prepares a Timelock-only deployment path for the verified Admin Safe.
- Requires explicit deploy confirmation and deploy-grade RPC confirmation before write mode.
- Rejects Radar/read-only fallback RPC as deploy-grade.
- Keeps Timelock address, deployment tx, block, block hash, verification URL, and artifact path as TBD until an approved ceremony is executed.

Planned Timelock model:
- Contract: ArcNSTimelock / OpenZeppelin TimelockController wrapper.
- Chain ID: 5042.
- minDelay: 172800 seconds.
- proposer: verified Admin Safe.
- executor: verified Admin Safe.
- canceller: verified Admin Safe.
- admin: address(0) / self-administered setup.

Script safety:
- Mainnet-specific.
- Deploys only Timelock when explicitly allowed.
- Performs no role migration.
- Performs no ownership transfer.
- Performs no protocol configuration.
- Performs no price/root/freeze/discount operation.
- Writes an artifact only after successful deployment and validation.
- Masks RPC data.
- Uses JSON-RPC batching disabled.
- Fails closed on missing confirmation, placeholders, Radar/read-only RPC, invalid config, or unsafe inputs.

Not included:
- No Timelock deployment.
- No contract deployment.
- No frontend deployment.
- No subgraph deployment.
- No live on-chain write.
- No signing.
- No private key used.
- No contract verification submission.
- No ownership or role transfer.
- No role grant or revocation.
- No root set/freeze/activation.
- No env, secret, key, API key, wallet material, or real deployment artifact changes.

Validation:
- git diff --check passed.
- node --check scripts/mainnet/deploy-timelock.js passed.
- node --check scripts/mainnet/check-timelock-config.js passed.
- node --check scripts/mainnet/check-safe-config.js passed.
- Restricted terminology scans passed.
- Local fail-closed guard probes passed.
- No deployment artifact was created.

Remaining blockers:
- Deploy-grade RPC selection and explicit approval.
- Deployer funding recheck immediately before ceremony.
- Secure PRIVATE_KEY supply at execution time.
- Explicit operator approval for Timelock deployment.
- Post-deploy read-only Timelock checker PASS.
- Timelock deployment record and artifact.
- Protocol contract deployment.
- Role/ownership handoff and deployer revocation.
- Blockscout verification path.
- Indexer/subgraph deployment.
- Frontend mainnet cutover.
- Discount lifecycle ceremonies.
- Final launch review.