### PR TITLE
chore: add mainnet rpc deploy-grade assessment

### DIFF
--- a/docs/mainnet/DEPLOYMENT_RUNBOOK.md
+++ b/docs/mainnet/DEPLOYMENT_RUNBOOK.md
@@ -12,11 +12,13 @@ The Timelock input register, OpenZeppelin version behavior, future dry-run cerem
 
 `scripts/mainnet/deploy-timelock.js` is prepared but has **not** been executed. It deploys only `ArcNSTimelock`; it does not migrate protocol ownership or roles or perform follow-on configuration. The Timelock address remains **TBD**.
 
-Write mode is forbidden until a deploy-grade Arc mainnet RPC is explicitly selected and approved (Radar does not qualify), the intended deployer is funded, an operator explicitly approves the ceremony, and every required exact confirmation environment value is supplied. This includes `CONFIRM_MAINNET_TIMELOCK_DEPLOY=I_UNDERSTAND_THIS_DEPLOYS_MAINNET_TIMELOCK`. Independently review the printed chain ID, deployer, balance, Admin Safe, delay, role recipients, masked RPC, and exact constructor arguments before execution. After a successful future deployment, `scripts/mainnet/check-timelock-config.js` must report **PASS** before any handoff activity.
+Write mode is forbidden until a deploy-grade Arc mainnet RPC is explicitly selected and approved, the intended deployer is funded, an operator explicitly approves the ceremony, and every required exact confirmation environment value is supplied. Radar remains rejected by the deployment guard; any future proposal to use it requires separately recorded explicit risk acceptance and a reviewed guard change. This includes `CONFIRM_MAINNET_TIMELOCK_DEPLOY=I_UNDERSTAND_THIS_DEPLOYS_MAINNET_TIMELOCK`. Independently review the printed chain ID, deployer, balance, Admin Safe, delay, role recipients, masked RPC, and exact constructor arguments before execution. After a successful future deployment, `scripts/mainnet/check-timelock-config.js` must report **PASS** before any handoff activity.
 
 `TIMELOCK_DEPLOY_DRY_RUN=1` is preflight-only and must not deploy or write an artifact. Mainnet launch remains **NO-GO** and handoff remains pending.
 
 Deploy-grade RPC acceptance and Blockscout verification blockers are tracked in [`DEPLOY_INFRA_READINESS.md`](./DEPLOY_INFRA_READINESS.md).
+
+Before considering any RPC for a future ceremony, run the read-only `node scripts/mainnet/assess-rpc-deploy-grade.js` procedure documented there. Supply only transient non-secret assessment inputs; optional known receipt and contract addresses improve evidence. A `PASS_READ_ONLY_ASSESSMENT` is not deployment approval. Provider provenance, operational ownership, limits, support/SLA, redundancy, and explicit human approval remain separate gates. Until those gates are recorded, deploy-grade RPC is unresolved, Timelock deployment is **NO-GO**, and mainnet launch is **NO-GO**.
 
 Mainnet indexer/subgraph inputs, event coverage, and frontend readiness gates are tracked in [`INDEXER_SUBGRAPH_PLAN.md`](./INDEXER_SUBGRAPH_PLAN.md).
 

--- a/docs/mainnet/DEPLOY_INFRA_READINESS.md
+++ b/docs/mainnet/DEPLOY_INFRA_READINESS.md
@@ -18,7 +18,7 @@ The consolidated launch inputs and Go/No-Go matrix are tracked in [`MAINNET_LAUN
 | Endpoint | Classification | Evidence | Allowed use | Launch blocker? |
 |---|---|---|---|---|
 | Blockdaemon authorized RPC | Candidate / `TBD` | Public request returned `401`; an authorized endpoint has not passed the complete checklist | None until authorization, testing, and explicit approval | Yes |
-| Radar RPC | Read-only/testing fallback only | Extended three-attempt read check and Hardhat preflight passed on 2026-08-03: chain `5042`, latest block data, USDC code/metadata, gas price, fee history, and provider fee data; not approved for signing or deployment | Read-only diagnostics and fallback reads | Yes — a primary is still required |
+| Radar RPC | Read-only/testing fallback only; deploy-grade assessment pending review | Extended readiness checks passed on 2026-08-03. Aşama 7C-2B adds a broader read-only candidate assessment, but technical read success cannot establish provider provenance, ownership, support, limits, or SLA and is not deployment approval. | Read-only diagnostics and fallback reads | Yes — explicit risk acceptance or a separately reviewed provider decision is still required |
 | Thirdweb public endpoint | Not deploy-grade | Returned chain ID but failed deeper reads | None for signing/deployment | Yes |
 | Infura / Alchemy project endpoint | Candidate only | Prior demo/project paths were not deploy-ready; Arc access and complete checks remain unproven | None until project-specific approval and checks pass | Yes |
 
@@ -48,6 +48,12 @@ An endpoint is not approved merely because a readiness script passes. Approval r
 - [ ] The deployment ceremony stops if the primary fails or returns inconsistent chain data.
 
 Read-only extended check: `node scripts/mainnet/check-rpc-readiness.js`. A `readiness-passed` result is evidence only and is not automatic deploy-RPC approval.
+
+### Deploy-grade candidate assessment procedure
+
+Run `node scripts/mainnet/assess-rpc-deploy-grade.js` with transient `RPC_URL`, `EXPECTED_CHAIN_ID=5042`, `DEPLOYER_ADDRESS`, and `ADMIN_SAFE_ADDRESS`. `REFERENCE_TX_HASH`, `USDC_ADDRESS`, and `SAMPLE_CONTRACT_ADDRESS` may be supplied for additional receipt/code evidence. The script disables JSON-RPC batching and performs only provider reads: chain/block/freshness, balance/nonces, fee capability, harmless gas estimation, Safe bytecode/view calls, optional receipt/log/code probes, and repeated block observations. It creates no signer, submits no transaction, and writes no artifact.
+
+`PASS_READ_ONLY_ASSESSMENT` means only that the tested read path behaved consistently at assessment time. It does not approve deployment use. Radar may be assessed, but even a technical PASS requires separately recorded human risk acceptance or a reviewed provider decision. `ALLOW_RADAR_DEPLOY_GRADE_CANDIDATE=1` only records explicit candidate consideration; it does not produce automatic approval. Keep the guarded Timelock deploy script's Radar rejection unchanged unless a later, separately reviewed change is explicitly approved. Deploy-grade RPC remains unresolved, Timelock deployment remains **NO-GO**, and mainnet launch remains **NO-GO**.
 
 ## Blockscout verification readiness
 

--- a/docs/mainnet/MAINNET_LAUNCH_INPUTS.md
+++ b/docs/mainnet/MAINNET_LAUNCH_INPUTS.md
@@ -18,6 +18,10 @@ Status: input register and readiness planning only. This document is not launch 
 
 Mainnet launch remains **NO-GO** and handoff remains pending. No address, transaction, block, or deployment artifact was created by this tooling phase.
 
+## Aşama 7C-2B RPC assessment status
+
+`scripts/mainnet/assess-rpc-deploy-grade.js` provides a signer-free, transaction-free candidate capability assessment using transient `RPC_URL`, `EXPECTED_CHAIN_ID=5042`, `DEPLOYER_ADDRESS`, and `ADMIN_SAFE_ADDRESS`, with optional known receipt and contract inputs. Its output separates a read-only technical verdict from the deploy-grade recommendation. A technical PASS is never automatic deployment approval. Radar assessment evidence still requires explicit risk acceptance or a separately reviewed provider decision, and the Timelock deploy guard remains unchanged. The deploy-grade RPC input remains `TBD`; Timelock and mainnet launch remain **NO-GO**.
+
 ## A. Executive summary
 
 - This document is the canonical launch input register and Go/No-Go readiness matrix; it is not a deployment instruction or launch approval.
@@ -127,6 +131,7 @@ Commands are recorded for future reviewed use. Environment values must be suppli
 | Command | Purpose | Required env/input | Capability | Allowed to run | Currently runnable? |
 |---|---|---|---|---|---|
 | `node scripts/mainnet/check-rpc-readiness.js` | Repeated chain, latest-block, USDC, gas, and fee-data readiness checks | `ARC_MAINNET_RPC_URL` as a real HTTPS endpoint; output masks tokenized paths/query values | Read-only network calls | During provider evaluation or pre-deployment recheck; never as automatic provider approval | Conditional only; no deploy-grade RPC is finalized |
+| `node scripts/mainnet/assess-rpc-deploy-grade.js` | Assess chain/block freshness, account reads, fee/estimate capability, Safe calls/code, optional receipt/log/code support, and repeated block stability; print a separate verdict and recommendation | Transient `RPC_URL`, `EXPECTED_CHAIN_ID=5042`, deployer and Admin Safe addresses; optional reference receipt/contract addresses | Read-only network calls, no signer, no artifact write, batching disabled | Candidate assessment only; never as automatic deployment approval | Yes for assessment; deploy-grade RPC remains unresolved |
 | `node scripts/mainnet/check-blockscout-readiness.js` | Harmless JSON reachability and API compatibility classification | `ARC_MAINNET_EXPLORER_API_URL` as a real HTTPS candidate; no API key required by the checker | Read-only HTTP GET | When the explorer owner supplies a reviewed API candidate; no verification submission | No; final API candidate is `TBD` |
 | `npx hardhat run scripts/preflight-arc-mainnet.js --network arc_mainnet` | Assert chain `5042`, latest block, and known USDC bytecode/symbol/decimals | Configured `arc_mainnet` read provider, normally via transient `ARC_MAINNET_RPC_URL` | Read-only network calls | Provider evaluation and final pre-deployment preflight only | Conditional for read-only fallback; not evidence of deploy-grade approval |
 | `node scripts/mainnet/validate-discount-proof-artifact.js` | Validate finalized artifact metadata, count, and every Merkle proof | Version-controlled finalized snapshot and bundled proof artifact; no env, signer, or RPC | Read-only, local and network-free | Any review/CI context | Yes |

--- a/docs/mainnet/SECURITY_CHECKLIST.md
+++ b/docs/mainnet/SECURITY_CHECKLIST.md
@@ -5,7 +5,8 @@
 - [x] Guarded mainnet-only `scripts/mainnet/deploy-timelock.js` prepared.
 - [x] Script scope limited to Timelock deployment; no protocol ownership/role migration or follow-on configuration.
 - [x] Dry-run mode designed to perform preflight only and write no artifact.
-- [ ] Deploy-grade RPC selected and explicitly approved (Radar does not qualify).
+- [x] Read-only deploy-grade candidate assessment procedure prepared; a technical PASS is evidence only and cannot authorize deployment.
+- [ ] Deploy-grade RPC selected and explicitly approved. Radar may be assessed, but use for deployment requires separately recorded risk acceptance or a reviewed provider decision; the deployment guard remains unchanged.
 - [ ] Deployer funding rechecked immediately before an approved ceremony.
 - [ ] Explicit operator approval and exact confirmation environment values supplied.
 - [ ] Timelock deployed and address recorded (currently **TBD / not deployed**).
@@ -15,6 +16,8 @@
 Until every unchecked item is satisfied, mainnet launch remains **NO-GO** and handoff remains pending.
 
 Infrastructure acceptance evidence: [`DEPLOY_INFRA_READINESS.md`](./DEPLOY_INFRA_READINESS.md).
+
+Run `node scripts/mainnet/assess-rpc-deploy-grade.js` only with transient assessment inputs and no signer. Review both its read-only verdict and separate deploy-grade recommendation. Do not treat Radar or any other endpoint as approved solely because read checks pass. Until provider provenance, ownership, limits, support/SLA, redundancy, and explicit human approval are recorded, Timelock deployment and mainnet launch remain **NO-GO**.
 
 Indexer/subgraph readiness evidence: [`INDEXER_SUBGRAPH_PLAN.md`](./INDEXER_SUBGRAPH_PLAN.md).
 

--- a/docs/mainnet/TIMELOCK_READINESS_PLAN.md
+++ b/docs/mainnet/TIMELOCK_READINESS_PLAN.md
@@ -10,6 +10,14 @@ Status: readiness documentation and read-only tooling preparation only. This is 
 - Actual execution requires a separately approved deploy-grade RPC (Radar remains read-only testing infrastructure), a funded deployer, explicit operator approval, all exact script confirmation environment values, and a post-deployment `scripts/mainnet/check-timelock-config.js` **PASS**.
 - Mainnet launch remains **NO-GO** and handoff remains pending.
 
+## Aşama 7C-2B RPC assessment gate (read-only)
+
+- `scripts/mainnet/assess-rpc-deploy-grade.js` evaluates candidate RPC read capability without a signer, transaction submission, write call, or artifact write.
+- Run it with transient `RPC_URL`, `EXPECTED_CHAIN_ID=5042`, `DEPLOYER_ADDRESS`, and `ADMIN_SAFE_ADDRESS`; optional known receipt and contract addresses add capability evidence.
+- A read-only PASS is necessary evidence only. It does not authorize Timelock deployment or establish provider provenance, ownership, support, limits, or SLA.
+- Radar can be assessed, but deployment use requires separately recorded explicit risk acceptance or a reviewed provider decision. The existing Timelock deploy guard remains fail-closed against Radar in this phase.
+- Deploy-grade RPC remains `TBD`; Timelock deployment and mainnet launch remain **NO-GO**.
+
 ## A. Executive summary
 
 - This is a Timelock readiness plan, not a deployment approval.
@@ -33,7 +41,7 @@ Status: readiness documentation and read-only tooling preparation only. This is 
 | Executor | Admin Safe (`0xFd48189D3Feb99a5cC6fcC6896744DAa73F3BF72`) | Approved input; deployment pending | Must hold `EXECUTOR_ROLE`; do not configure an open executor without explicit review. |
 | Canceller | Admin Safe (`0xFd48189D3Feb99a5cC6fcC6896744DAa73F3BF72`) | Approved input; deployment pending | OpenZeppelin v5 grants `CANCELLER_ROLE` to constructor proposers. |
 | Deployer | `TBD` | Blocked | Confirm exact deployment operator and funding during the future ceremony. |
-| Deploy-grade RPC | `TBD` | Blocked | Radar must not be promoted from read-only/testing use. |
+| Deploy-grade RPC | `TBD` | Blocked | Read-only assessment does not approve a provider. Radar requires explicit risk acceptance or a separately reviewed provider decision, and remains rejected by the deployment guard in this phase. |
 | Timelock address | `TBD` | Blocked | Record only after deployment and read-only verification. |
 | Deployment tx hash | `TBD` | Blocked | Do not infer from any testnet deployment. |
 | Deployment block | `TBD` | Blocked | Record from the successful receipt. |

--- a/scripts/mainnet/assess-rpc-deploy-grade.js
+++ b/scripts/mainnet/assess-rpc-deploy-grade.js
@@ -1,0 +1,431 @@
+"use strict";
+
+/**
+ * Read-only Arc mainnet RPC capability assessment.
+ *
+ * This script creates no signer, submits no transaction, calls no contract
+ * write method, and writes no files. A PASS is capability evidence only; it
+ * is never sufficient by itself to approve an endpoint for deployment use.
+ */
+
+const { ethers } = require("ethers");
+
+const ARC_MAINNET_CHAIN_ID = 5042n;
+const MAX_BLOCK_AGE_SECONDS = 300;
+const BLOCK_OBSERVATIONS = 3;
+const BLOCK_OBSERVATION_DELAY_MS = 1000;
+const CHECK_PACING_DELAY_MS = 500;
+const RECENT_LOG_BLOCK_RANGE = 10;
+const PLACEHOLDER_PATTERN = /(?:^|[\W_])(?:tbd|todo|null|undefined|placeholder|changeme|replace[_-]?me|example|your[_-]?)(?:$|[\W_])|<[^>]*>/i;
+const RADAR_PATTERN = /radar(?:-api)?-rpc|radar.*railway|railway.*radar/i;
+const SAFE_ABI = [
+  "function getOwners() view returns (address[])",
+  "function getThreshold() view returns (uint256)",
+];
+
+function requiredValue(env, name) {
+  const value = String(env[name] || "").trim();
+  if (!value || PLACEHOLDER_PATTERN.test(value)) {
+    throw new Error(`${name} is required and must not be empty or a placeholder`);
+  }
+  return value;
+}
+
+function optionalValue(env, name) {
+  const value = String(env[name] || "").trim();
+  if (!value) return undefined;
+  if (PLACEHOLDER_PATTERN.test(value)) {
+    throw new Error(`${name} must not be a placeholder when supplied`);
+  }
+  return value;
+}
+
+function checkedFlag(env, name) {
+  const value = String(env[name] || "0").trim();
+  if (!/^[01]$/.test(value)) throw new Error(`${name} must be 0 or 1 when supplied`);
+  return value === "1";
+}
+
+function checkedAddress(value, name) {
+  try {
+    const address = ethers.getAddress(value);
+    if (address === ethers.ZeroAddress) throw new Error("zero address");
+    return address;
+  } catch (_) {
+    throw new Error(`${name} must be a valid non-zero address`);
+  }
+}
+
+function checkedHash(value, name) {
+  if (!/^0x[0-9a-fA-F]{64}$/.test(value)) throw new Error(`${name} must be a 32-byte transaction hash`);
+  return value;
+}
+
+function checkedRpcUrl(value) {
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch (_) {
+    throw new Error("RPC_URL must be a valid HTTPS URL");
+  }
+  if (parsed.protocol !== "https:") throw new Error("RPC_URL must use HTTPS");
+  return { parsed, value };
+}
+
+function maskRpcUrl(value) {
+  try {
+    const url = new URL(value);
+    url.username = url.username ? "***" : "";
+    url.password = url.password ? "***" : "";
+    if (url.pathname !== "/") url.pathname = "/***";
+    if (url.search) url.search = "?***=masked";
+    return url.toString().replace(/\/$/, "");
+  } catch (_) {
+    return "<masked-invalid-rpc-url>";
+  }
+}
+
+function safeErrorMessage(error) {
+  return String(error?.shortMessage || error?.message || error || "unknown error")
+    .replace(/https?:\/\/[^\s)\]}]+/gi, "<masked-rpc-url>");
+}
+
+function loadConfig(env = process.env) {
+  const rpc = checkedRpcUrl(requiredValue(env, "RPC_URL"));
+  const expectedChainIdValue = requiredValue(env, "EXPECTED_CHAIN_ID");
+  if (!/^\d+$/.test(expectedChainIdValue) || BigInt(expectedChainIdValue) !== ARC_MAINNET_CHAIN_ID) {
+    throw new Error(`EXPECTED_CHAIN_ID must equal ${ARC_MAINNET_CHAIN_ID}`);
+  }
+
+  const referenceTxHash = optionalValue(env, "REFERENCE_TX_HASH");
+  const usdcAddress = optionalValue(env, "USDC_ADDRESS");
+  const sampleContractAddress = optionalValue(env, "SAMPLE_CONTRACT_ADDRESS");
+
+  return {
+    rpcUrl: rpc.value,
+    rpcMasked: maskRpcUrl(rpc.value),
+    isRadar: RADAR_PATTERN.test(rpc.value) || RADAR_PATTERN.test(rpc.parsed.hostname),
+    expectedChainId: ARC_MAINNET_CHAIN_ID,
+    deployerAddress: checkedAddress(requiredValue(env, "DEPLOYER_ADDRESS"), "DEPLOYER_ADDRESS"),
+    adminSafeAddress: checkedAddress(requiredValue(env, "ADMIN_SAFE_ADDRESS"), "ADMIN_SAFE_ADDRESS"),
+    referenceTxHash: referenceTxHash ? checkedHash(referenceTxHash, "REFERENCE_TX_HASH") : undefined,
+    usdcAddress: usdcAddress ? checkedAddress(usdcAddress, "USDC_ADDRESS") : undefined,
+    sampleContractAddress: sampleContractAddress
+      ? checkedAddress(sampleContractAddress, "SAMPLE_CONTRACT_ADDRESS")
+      : undefined,
+    allowRadarCandidate: checkedFlag(env, "ALLOW_RADAR_DEPLOY_GRADE_CANDIDATE"),
+    reviewedProviderApproved: checkedFlag(env, "REVIEWED_DEPLOY_GRADE_PROVIDER_APPROVED"),
+  };
+}
+
+function printable(value) {
+  if (typeof value === "bigint") return value.toString();
+  if (Array.isArray(value)) return value.map(printable);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, printable(item)]));
+  }
+  return value;
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function main() {
+  let config;
+  try {
+    config = loadConfig();
+  } catch (error) {
+    console.error(`configurationError: ${safeErrorMessage(error)}`);
+    console.log("verdict: FAIL_READ_ONLY_ASSESSMENT");
+    console.log("deployGradeRecommendation: NOT_APPROVED");
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log("ArcNS RPC deploy-grade candidate assessment (READ-ONLY)");
+  console.log(`rpc: ${config.rpcMasked}`);
+  console.log(`expectedChainId: ${config.expectedChainId}`);
+  console.log(`providerClassification: ${config.isRadar ? "RADAR" : "OTHER"}`);
+  console.log("batching: disabled (batchMaxCount=1)");
+
+  const provider = new ethers.JsonRpcProvider(
+    config.rpcUrl,
+    config.expectedChainId,
+    { staticNetwork: true, batchMaxCount: 1 }
+  );
+  const results = [];
+  let latestBlockNumber;
+
+  async function check(name, mandatory, operation, validate = () => true) {
+    try {
+      const value = await operation();
+      if (!validate(value)) throw new Error("returned invalid or unexpected data");
+      results.push({ name, mandatory, status: "PASS", detail: printable(value) });
+      console.log(`check ${name}: PASS`);
+      return value;
+    } catch (error) {
+      results.push({ name, mandatory, status: "FAIL", detail: safeErrorMessage(error) });
+      console.log(`check ${name}: FAIL (${safeErrorMessage(error)})`);
+      return undefined;
+    } finally {
+      // Avoid turning a sequential capability assessment into an accidental
+      // burst against endpoints with conservative per-project rate limits.
+      await delay(CHECK_PACING_DELAY_MS);
+    }
+  }
+
+  async function optionalCheck(name, operation, validate = () => true) {
+    try {
+      const value = await operation();
+      if (!validate(value)) throw new Error("returned invalid or unexpected data");
+      results.push({ name, mandatory: false, status: "PASS", detail: printable(value) });
+      console.log(`check ${name}: PASS`);
+      return value;
+    } catch (error) {
+      results.push({ name, mandatory: false, status: "UNSUPPORTED_OR_UNAVAILABLE", detail: safeErrorMessage(error) });
+      console.log(`check ${name}: UNSUPPORTED_OR_UNAVAILABLE (${safeErrorMessage(error)})`);
+      return undefined;
+    } finally {
+      await delay(CHECK_PACING_DELAY_MS);
+    }
+  }
+
+  function skipped(name, reason) {
+    results.push({ name, mandatory: false, status: "SKIPPED", detail: reason });
+    console.log(`check ${name}: SKIPPED (${reason})`);
+  }
+
+  await check(
+    "chainId",
+    true,
+    async () => (await provider.getNetwork()).chainId,
+    (chainId) => chainId === config.expectedChainId
+  );
+  await check(
+    "noBatchCompatibility",
+    true,
+    () => provider.send("eth_chainId", []),
+    (value) => typeof value === "string" && BigInt(value) === config.expectedChainId
+  );
+  latestBlockNumber = await check(
+    "latestBlockNumber",
+    true,
+    () => provider.getBlockNumber(),
+    (value) => Number.isSafeInteger(value) && value > 0
+  );
+
+  const latestBlock = latestBlockNumber === undefined
+    ? undefined
+    : await check(
+      "latestBlockObject",
+      true,
+      () => provider.getBlock(latestBlockNumber),
+      (block) => block && block.number === latestBlockNumber && /^0x[0-9a-f]{64}$/i.test(block.hash || "")
+    );
+
+  if (latestBlock) {
+    await check(
+      "latestBlockFreshness",
+      true,
+      async () => {
+        const localTimestamp = Math.floor(Date.now() / 1000);
+        const ageSeconds = localTimestamp - latestBlock.timestamp;
+        return { blockTimestamp: latestBlock.timestamp, localTimestamp, ageSeconds, maximumAgeSeconds: MAX_BLOCK_AGE_SECONDS };
+      },
+      ({ ageSeconds }) => ageSeconds >= -30 && ageSeconds <= MAX_BLOCK_AGE_SECONDS
+    );
+  } else {
+    results.push({ name: "latestBlockFreshness", mandatory: true, status: "FAIL", detail: "latest block object unavailable" });
+    console.log("check latestBlockFreshness: FAIL (latest block object unavailable)");
+  }
+
+  await check(
+    "deployerBalance",
+    true,
+    () => provider.getBalance(config.deployerAddress),
+    (value) => typeof value === "bigint" && value >= 0n
+  );
+  const latestNonce = await check(
+    "deployerNonceLatest",
+    true,
+    () => provider.getTransactionCount(config.deployerAddress, "latest"),
+    (value) => Number.isSafeInteger(value) && value >= 0
+  );
+  const pendingNonce = await check(
+    "deployerNoncePending",
+    true,
+    () => provider.getTransactionCount(config.deployerAddress, "pending"),
+    (value) => Number.isSafeInteger(value) && value >= 0
+  );
+  if (latestNonce !== undefined && pendingNonce !== undefined && pendingNonce < latestNonce) {
+    results.push({ name: "deployerNonceOrdering", mandatory: true, status: "FAIL", detail: "pending nonce is below latest nonce" });
+    console.log("check deployerNonceOrdering: FAIL (pending nonce is below latest nonce)");
+  } else if (latestNonce !== undefined && pendingNonce !== undefined) {
+    results.push({ name: "deployerNonceOrdering", mandatory: true, status: "PASS", detail: { latestNonce, pendingNonce } });
+    console.log("check deployerNonceOrdering: PASS");
+  }
+
+  await check(
+    "feeData",
+    true,
+    () => provider.getFeeData(),
+    (value) => value && [value.gasPrice, value.maxFeePerGas, value.maxPriorityFeePerGas].some((item) => typeof item === "bigint" && item > 0n)
+  );
+  await optionalCheck(
+    "feeHistory",
+    () => provider.send("eth_feeHistory", ["0x3", "latest", [25, 50, 75]]),
+    (value) => value && Array.isArray(value.baseFeePerGas) && value.baseFeePerGas.length > 0
+  );
+  await check(
+    "zeroValueSelfTransferGasEstimate",
+    true,
+    () => provider.estimateGas({
+      from: config.deployerAddress,
+      to: config.deployerAddress,
+      value: 0n,
+    }),
+    (value) => typeof value === "bigint" && value > 0n
+  );
+
+  await check(
+    "adminSafeCode",
+    true,
+    () => provider.getCode(config.adminSafeAddress),
+    (value) => /^0x[0-9a-f]+$/i.test(value) && value !== "0x"
+  );
+  const safe = new ethers.Contract(config.adminSafeAddress, SAFE_ABI, provider);
+  const safeOwners = await check(
+    "safeGetOwnersEthCall",
+    true,
+    () => safe.getOwners(),
+    (owners) => Array.isArray(owners) && owners.length > 0 && owners.every(ethers.isAddress)
+  );
+  const safeThreshold = await check(
+    "safeGetThresholdEthCall",
+    true,
+    () => safe.getThreshold(),
+    (threshold) => typeof threshold === "bigint" && threshold > 0n
+  );
+  if (safeOwners && safeThreshold) {
+    await check(
+      "safeThresholdConsistency",
+      true,
+      async () => ({ ownerCount: safeOwners.length, threshold: safeThreshold }),
+      ({ ownerCount, threshold }) => threshold <= BigInt(ownerCount)
+    );
+  }
+
+  if (config.referenceTxHash) {
+    await check(
+      "referenceTransactionReceipt",
+      true,
+      () => provider.getTransactionReceipt(config.referenceTxHash),
+      (receipt) => receipt && receipt.hash.toLowerCase() === config.referenceTxHash.toLowerCase() && receipt.blockNumber > 0
+    );
+  } else {
+    skipped("referenceTransactionReceipt", "REFERENCE_TX_HASH not supplied");
+  }
+
+  if (latestBlockNumber !== undefined) {
+    await optionalCheck(
+      "recentSafeLogs",
+      () => provider.getLogs({
+        address: config.adminSafeAddress,
+        fromBlock: Math.max(0, latestBlockNumber - RECENT_LOG_BLOCK_RANGE),
+        toBlock: latestBlockNumber,
+      }),
+      (logs) => Array.isArray(logs)
+    );
+  } else {
+    skipped("recentSafeLogs", "latest block number unavailable");
+  }
+
+  if (config.usdcAddress) {
+    await optionalCheck(
+      "usdcCode",
+      () => provider.getCode(config.usdcAddress),
+      (value) => /^0x[0-9a-f]+$/i.test(value) && value !== "0x"
+    );
+  } else {
+    skipped("usdcCode", "USDC_ADDRESS not supplied");
+  }
+
+  if (config.sampleContractAddress) {
+    await optionalCheck(
+      "sampleContractCode",
+      () => provider.getCode(config.sampleContractAddress),
+      (value) => /^0x[0-9a-f]+$/i.test(value) && value !== "0x"
+    );
+  } else {
+    skipped("sampleContractCode", "SAMPLE_CONTRACT_ADDRESS not supplied");
+  }
+
+  await check(
+    "repeatedBlockNumberStability",
+    true,
+    async () => {
+      const observations = [];
+      for (let index = 0; index < BLOCK_OBSERVATIONS; index += 1) {
+        observations.push(await provider.getBlockNumber());
+        if (index + 1 < BLOCK_OBSERVATIONS) await delay(BLOCK_OBSERVATION_DELAY_MS);
+      }
+      return observations;
+    },
+    (observations) => observations.length === BLOCK_OBSERVATIONS
+      && observations.every((value) => Number.isSafeInteger(value) && value > 0)
+      && observations.every((value, index) => index === 0 || value >= observations[index - 1])
+  );
+
+  const mandatoryFailures = results.filter((result) => result.mandatory && result.status === "FAIL");
+  const optionalUnavailable = results.filter((result) => result.status === "UNSUPPORTED_OR_UNAVAILABLE");
+  const verdict = mandatoryFailures.length > 0
+    ? "FAIL_READ_ONLY_ASSESSMENT"
+    : optionalUnavailable.length > 0
+      ? "INCONCLUSIVE_READ_ONLY_ASSESSMENT"
+      : "PASS_READ_ONLY_ASSESSMENT";
+
+  let recommendation;
+  let recommendationReason;
+  if (mandatoryFailures.length > 0) {
+    recommendation = "NOT_APPROVED";
+    recommendationReason = "One or more critical mandatory read-only checks failed.";
+  } else if (config.isRadar) {
+    recommendation = "CONDITIONAL_RISK_ACCEPTANCE_REQUIRED";
+    recommendationReason = config.allowRadarCandidate
+      ? "Radar candidacy was explicitly acknowledged, but provider provenance, ownership, support, limits, and SLA still require documented human risk acceptance."
+      : "Radar read capability does not resolve provider provenance, ownership, support, limits, or SLA; its deployment use remains blocked without explicit risk acceptance.";
+  } else if (verdict === "PASS_READ_ONLY_ASSESSMENT" && config.reviewedProviderApproved) {
+    recommendation = "APPROVED";
+    recommendationReason = "Read-only checks passed and the environment explicitly records separate reviewed-provider approval; retain independent human evidence.";
+  } else {
+    recommendation = "CONDITIONAL_RISK_ACCEPTANCE_REQUIRED";
+    recommendationReason = "Read-only capability evidence alone does not establish reviewed provider provenance, operational ownership, support, limits, or SLA.";
+  }
+
+  console.log("\nAssessment summary");
+  console.log(`mandatoryChecksFailed: ${mandatoryFailures.length}`);
+  console.log(`optionalMethodsUnsupportedOrUnavailable: ${optionalUnavailable.length}`);
+  console.log(`verdict: ${verdict}`);
+  console.log(`deployGradeRecommendation: ${recommendation}`);
+  console.log(`recommendationReason: ${recommendationReason}`);
+  console.log("readOnlySuccessIsDeploymentApproval: NO");
+
+  if (verdict === "FAIL_READ_ONLY_ASSESSMENT") process.exitCode = 1;
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(`assessmentError: ${safeErrorMessage(error)}`);
+    console.log("verdict: FAIL_READ_ONLY_ASSESSMENT");
+    console.log("deployGradeRecommendation: NOT_APPROVED");
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  loadConfig,
+  main,
+  maskRpcUrl,
+  safeErrorMessage,
+};


### PR DESCRIPTION
This PR adds a read-only RPC deploy-grade assessment tool and records the Radar assessment result for Aşama 7C-2B.

Included:
- Adds scripts/mainnet/assess-rpc-deploy-grade.js.
- Updates deploy infrastructure readiness, Timelock readiness, deployment runbook, launch inputs, and security checklist docs.
- Adds a read-only assessment flow for RPC candidates before Timelock deployment.
- Documents that read-only success alone does not approve deployment use.
- Records that Radar remains read-only/testing infrastructure and is not approved as deploy-grade.

Radar assessment:
- Assessment executed: yes.
- Result: FAIL_READ_ONLY_ASSESSMENT.
- Recommendation: NOT_APPROVED.
- Mandatory failures: 13.
- Optional unavailable methods: 2.
- Observed instability included HTTP 404 behavior and provider retry failure.
- deploy-timelock.js was not changed and continues to reject Radar.

Not included:
- No Timelock deployment.
- No contract deployment.
- No frontend deployment.
- No subgraph deployment.
- No live on-chain write.
- No signing.
- No private key used.
- No eth_sendRawTransaction call.
- No contract verification submission.
- No ownership or role transfer.
- No root set/freeze/activation.
- No env, secret, key, API key, wallet material, or deployment artifact changes.

Validation:
- git diff --check passed.
- node --check scripts/mainnet/assess-rpc-deploy-grade.js passed.
- node --check scripts/mainnet/deploy-timelock.js passed.
- node --check scripts/mainnet/check-timelock-config.js passed.
- node --check scripts/mainnet/check-safe-config.js passed.
- Restricted terminology scans passed.

Remaining blockers:
- Approved deploy-grade RPC provider is still required.
- Timelock remains undeployed.
- Blockscout verification path remains unresolved.
- Protocol deployment remains pending.
- Authority handoff and deployer revocation remain pending.
- Indexer/subgraph readiness remains pending.
- Frontend mainnet cutover remains pending.
- Final launch review remains pending.