### PR TITLE
chore: add authenticated rpc support

### DIFF
--- a/docs/mainnet/DEPLOYMENT_RUNBOOK.md
+++ b/docs/mainnet/DEPLOYMENT_RUNBOOK.md
@@ -18,6 +18,8 @@ Write mode is forbidden until a deploy-grade Arc mainnet RPC is explicitly selec
 
 Deploy-grade RPC acceptance and Blockscout verification blockers are tracked in [`DEPLOY_INFRA_READINESS.md`](./DEPLOY_INFRA_READINESS.md).
 
+For a future provider that requires access headers, supply `RPC_AUTH_MODE` as `none`, `bearer`, `x-api-key`, or `custom` at execution time only. Use the corresponding transient token/header environment variables; never put a token in the RPC URL or commit, log, paste, or artifact it. Authenticated connectivity is only technical capability evidence and does not resolve the deploy-grade approval blocker.
+
 Before considering any RPC for a future ceremony, run the read-only `node scripts/mainnet/assess-rpc-deploy-grade.js` procedure documented there. Supply only transient non-secret assessment inputs; optional known receipt and contract addresses improve evidence. A `PASS_READ_ONLY_ASSESSMENT` is not deployment approval. Provider provenance, operational ownership, limits, support/SLA, redundancy, and explicit human approval remain separate gates. Until those gates are recorded, deploy-grade RPC is unresolved, Timelock deployment is **NO-GO**, and mainnet launch is **NO-GO**.
 
 Mainnet indexer/subgraph inputs, event coverage, and frontend readiness gates are tracked in [`INDEXER_SUBGRAPH_PLAN.md`](./INDEXER_SUBGRAPH_PLAN.md).

--- a/docs/mainnet/DEPLOY_INFRA_READINESS.md
+++ b/docs/mainnet/DEPLOY_INFRA_READINESS.md
@@ -24,6 +24,10 @@ The consolidated launch inputs and Go/No-Go matrix are tracked in [`MAINNET_LAUN
 
 No secret or tokenized URL is recorded here. Deployment evidence must mask credentials and query strings.
 
+### Authenticated RPC handling (Aşama 7C-2C)
+
+Some future deploy-grade providers may require header authentication. The mainnet tooling accepts `RPC_AUTH_MODE=none|bearer|x-api-key|custom`; bearer mode uses `RPC_BEARER_TOKEN`, x-api-key mode uses `RPC_X_API_KEY`, and custom mode uses `RPC_AUTH_HEADER_NAME` plus `RPC_AUTH_HEADER_VALUE`. The default is `none`. Supply these values only through the transient execution environment or an approved secret manager. Never embed credentials in an RPC URL, commit or log tokens, paste them into pull requests, or write them to deployment artifacts. Tool output records only the masked RPC URL, auth mode, and whether auth was provided. Authenticated access does not approve a provider; deploy-grade RPC remains `TBD`.
+
 ## Deploy-grade RPC acceptance criteria
 
 An endpoint is not approved merely because a readiness script passes. Approval requires all of the following:

--- a/docs/mainnet/MAINNET_LAUNCH_INPUTS.md
+++ b/docs/mainnet/MAINNET_LAUNCH_INPUTS.md
@@ -37,6 +37,8 @@ Mainnet launch remains **NO-GO** and handoff remains pending. No address, transa
 
 `TBD` and any status other than Final/Approved are blocking where the final column says Yes. Provider URLs recorded as evidence must be masked; credentials and query values must never be copied here.
 
+Future deploy-grade RPC access may use `RPC_AUTH_MODE=none|bearer|x-api-key|custom`. Header tokens and custom header values are execution-time secrets only: do not put them in URLs, commit them, log them, paste them into PRs, or write them to artifacts. Authentication support does not change the unresolved/TBD provider approval gate.
+
 | Input | Required value | Status | Source / owner | Validation method | Blocks deploy? |
 |---|---|---|---|---|---|
 | Deployer EOA | `0x0b943Fe9f1f8135e0751BA8B43dc0cD688ad209D` | Selected; final verification pending | Deployment operator / final launch review | Independently verify address, operator control, and deployment-only authority boundary | Yes |

--- a/docs/mainnet/SECURITY_CHECKLIST.md
+++ b/docs/mainnet/SECURITY_CHECKLIST.md
@@ -17,6 +17,8 @@ Until every unchecked item is satisfied, mainnet launch remains **NO-GO** and ha
 
 Infrastructure acceptance evidence: [`DEPLOY_INFRA_READINESS.md`](./DEPLOY_INFRA_READINESS.md).
 
+- [ ] If the future deploy-grade RPC requires authentication, use only transient `RPC_AUTH_MODE=none|bearer|x-api-key|custom` environment inputs; never place tokens in URLs, commits, logs, PRs, or artifacts.
+
 Run `node scripts/mainnet/assess-rpc-deploy-grade.js` only with transient assessment inputs and no signer. Review both its read-only verdict and separate deploy-grade recommendation. Do not treat Radar or any other endpoint as approved solely because read checks pass. Until provider provenance, ownership, limits, support/SLA, redundancy, and explicit human approval are recorded, Timelock deployment and mainnet launch remain **NO-GO**.
 
 Indexer/subgraph readiness evidence: [`INDEXER_SUBGRAPH_PLAN.md`](./INDEXER_SUBGRAPH_PLAN.md).

--- a/docs/mainnet/TIMELOCK_READINESS_PLAN.md
+++ b/docs/mainnet/TIMELOCK_READINESS_PLAN.md
@@ -18,6 +18,10 @@ Status: readiness documentation and read-only tooling preparation only. This is 
 - Radar can be assessed, but deployment use requires separately recorded explicit risk acceptance or a reviewed provider decision. The existing Timelock deploy guard remains fail-closed against Radar in this phase.
 - Deploy-grade RPC remains `TBD`; Timelock deployment and mainnet launch remain **NO-GO**.
 
+### Aşama 7C-2C authenticated RPC preparation
+
+Future providers may require header authentication. The guarded scripts support `RPC_AUTH_MODE=none|bearer|x-api-key|custom` (default `none`) using transient `RPC_BEARER_TOKEN`, `RPC_X_API_KEY`, or custom header name/value environment variables. Credentials must never be placed in URLs, committed, logged, pasted into PRs, or written to artifacts. The scripts expose only masked RPC/auth metadata and do not weaken the Radar rejection, confirmation gates, signer boundary, or Timelock **NO-GO** status.
+
 ## A. Executive summary
 
 - This is a Timelock readiness plan, not a deployment approval.

--- a/scripts/mainnet/assess-rpc-deploy-grade.js
+++ b/scripts/mainnet/assess-rpc-deploy-grade.js
@@ -9,6 +9,7 @@
  */
 
 const { ethers } = require("ethers");
+const { createRpcProvider, loadRpcConfig, sanitizeRpcError } = require("./lib/rpc-provider");
 
 const ARC_MAINNET_CHAIN_ID = 5042n;
 const MAX_BLOCK_AGE_SECONDS = 300;
@@ -61,37 +62,12 @@ function checkedHash(value, name) {
   return value;
 }
 
-function checkedRpcUrl(value) {
-  let parsed;
-  try {
-    parsed = new URL(value);
-  } catch (_) {
-    throw new Error("RPC_URL must be a valid HTTPS URL");
-  }
-  if (parsed.protocol !== "https:") throw new Error("RPC_URL must use HTTPS");
-  return { parsed, value };
-}
-
-function maskRpcUrl(value) {
-  try {
-    const url = new URL(value);
-    url.username = url.username ? "***" : "";
-    url.password = url.password ? "***" : "";
-    if (url.pathname !== "/") url.pathname = "/***";
-    if (url.search) url.search = "?***=masked";
-    return url.toString().replace(/\/$/, "");
-  } catch (_) {
-    return "<masked-invalid-rpc-url>";
-  }
-}
-
 function safeErrorMessage(error) {
-  return String(error?.shortMessage || error?.message || error || "unknown error")
-    .replace(/https?:\/\/[^\s)\]}]+/gi, "<masked-rpc-url>");
+  return sanitizeRpcError(error);
 }
 
 function loadConfig(env = process.env) {
-  const rpc = checkedRpcUrl(requiredValue(env, "RPC_URL"));
+  const rpc = loadRpcConfig(env, "RPC_URL", { requireHttps: true });
   const expectedChainIdValue = requiredValue(env, "EXPECTED_CHAIN_ID");
   if (!/^\d+$/.test(expectedChainIdValue) || BigInt(expectedChainIdValue) !== ARC_MAINNET_CHAIN_ID) {
     throw new Error(`EXPECTED_CHAIN_ID must equal ${ARC_MAINNET_CHAIN_ID}`);
@@ -102,9 +78,12 @@ function loadConfig(env = process.env) {
   const sampleContractAddress = optionalValue(env, "SAMPLE_CONTRACT_ADDRESS");
 
   return {
-    rpcUrl: rpc.value,
-    rpcMasked: maskRpcUrl(rpc.value),
-    isRadar: RADAR_PATTERN.test(rpc.value) || RADAR_PATTERN.test(rpc.parsed.hostname),
+    rpcUrl: rpc.rpcUrl,
+    rpcMasked: rpc.rpcMasked,
+    authMode: rpc.authMode,
+    authProvided: rpc.authProvided,
+    authConfig: rpc,
+    isRadar: RADAR_PATTERN.test(rpc.rpcUrl) || RADAR_PATTERN.test(rpc.parsed.hostname),
     expectedChainId: ARC_MAINNET_CHAIN_ID,
     deployerAddress: checkedAddress(requiredValue(env, "DEPLOYER_ADDRESS"), "DEPLOYER_ADDRESS"),
     adminSafeAddress: checkedAddress(requiredValue(env, "ADMIN_SAFE_ADDRESS"), "ADMIN_SAFE_ADDRESS"),
@@ -147,13 +126,11 @@ async function main() {
   console.log(`rpc: ${config.rpcMasked}`);
   console.log(`expectedChainId: ${config.expectedChainId}`);
   console.log(`providerClassification: ${config.isRadar ? "RADAR" : "OTHER"}`);
+  console.log(`authMode: ${config.authMode}`);
+  console.log(`authProvided: ${config.authProvided}`);
   console.log("batching: disabled (batchMaxCount=1)");
 
-  const provider = new ethers.JsonRpcProvider(
-    config.rpcUrl,
-    config.expectedChainId,
-    { staticNetwork: true, batchMaxCount: 1 }
-  );
+  const provider = createRpcProvider(config.authConfig, config.expectedChainId, { staticNetwork: true });
   const results = [];
   let latestBlockNumber;
 
@@ -391,10 +368,10 @@ async function main() {
     recommendation = "NOT_APPROVED";
     recommendationReason = "One or more critical mandatory read-only checks failed.";
   } else if (config.isRadar) {
-    recommendation = "CONDITIONAL_RISK_ACCEPTANCE_REQUIRED";
+    recommendation = "NOT_APPROVED";
     recommendationReason = config.allowRadarCandidate
-      ? "Radar candidacy was explicitly acknowledged, but provider provenance, ownership, support, limits, and SLA still require documented human risk acceptance."
-      : "Radar read capability does not resolve provider provenance, ownership, support, limits, or SLA; its deployment use remains blocked without explicit risk acceptance.";
+      ? "Radar candidacy acknowledgement does not override its failed deploy-grade assessment; deployment use remains rejected."
+      : "Radar failed deploy-grade assessment and remains rejected for deployment use.";
   } else if (verdict === "PASS_READ_ONLY_ASSESSMENT" && config.reviewedProviderApproved) {
     recommendation = "APPROVED";
     recommendationReason = "Read-only checks passed and the environment explicitly records separate reviewed-provider approval; retain independent human evidence.";
@@ -426,6 +403,5 @@ if (require.main === module) {
 module.exports = {
   loadConfig,
   main,
-  maskRpcUrl,
   safeErrorMessage,
 };

--- a/scripts/mainnet/check-safe-config.js
+++ b/scripts/mainnet/check-safe-config.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const { ethers } = require("ethers");
+const { createRpcProvider, loadRpcConfig, sanitizeRpcError } = require("./lib/rpc-provider");
 
 const SAFE_ABI = [
   "function getOwners() view returns (address[])",
@@ -38,28 +39,10 @@ function checkedAddress(value, name) {
   }
 }
 
-function maskRpcUrl(value) {
-  try {
-    const url = new URL(value);
-    return `${url.protocol}//${url.host}/***`;
-  } catch (_) {
-    return "<masked-invalid-url>";
-  }
-}
-
 function loadConfig(env = process.env) {
   for (const name of REQUIRED_ENV) requiredValue(env, name);
 
-  const rpcUrl = requiredValue(env, "SAFE_RPC_URL");
-  let parsedRpc;
-  try {
-    parsedRpc = new URL(rpcUrl);
-  } catch (_) {
-    throw new Error("SAFE_RPC_URL must be a valid HTTP(S) URL");
-  }
-  if (!/^https?:$/.test(parsedRpc.protocol)) {
-    throw new Error("SAFE_RPC_URL must use HTTP or HTTPS");
-  }
+  const rpc = loadRpcConfig(env, "SAFE_RPC_URL", { requireHttps: false });
 
   const ownerEntries = requiredValue(env, "EXPECTED_SAFE_OWNERS").split(",").map((owner) => owner.trim());
   if (ownerEntries.some((owner) => !owner || PLACEHOLDER_PATTERN.test(owner))) {
@@ -84,7 +67,8 @@ function loadConfig(env = process.env) {
   }
 
   return {
-    rpcUrl,
+    rpcUrl: rpc.rpcUrl,
+    rpcConfig: rpc,
     expectedChainId: positiveInteger(requiredValue(env, "EXPECTED_CHAIN_ID"), "EXPECTED_CHAIN_ID"),
     safeAddress,
     owners,
@@ -94,10 +78,11 @@ function loadConfig(env = process.env) {
 
 async function main() {
   const config = loadConfig();
-  console.log(`RPC: ${maskRpcUrl(config.rpcUrl)}`);
+  console.log(`RPC: ${config.rpcConfig.rpcMasked}`);
+  console.log(`Auth mode: ${config.rpcConfig.authMode}; auth provided: ${config.rpcConfig.authProvided}`);
 
   // Disable batching for RPC providers that reject JSON-RPC batch requests.
-  const provider = new ethers.JsonRpcProvider(config.rpcUrl, config.expectedChainId, { batchMaxCount: 1 });
+  const provider = createRpcProvider(config.rpcConfig, config.expectedChainId);
   const network = await provider.getNetwork();
   if (network.chainId !== config.expectedChainId) {
     throw new Error(`Chain ID mismatch: expected ${config.expectedChainId}, received ${network.chainId}`);
@@ -128,9 +113,9 @@ async function main() {
 
 if (require.main === module) {
   main().catch((error) => {
-    console.error(`FAIL: ${error.message.replace(/https?:\/\/[^\s)]+/gi, "<masked-rpc-url>")}`);
+    console.error(`FAIL: ${sanitizeRpcError(error)}`);
     process.exit(1);
   });
 }
 
-module.exports = { loadConfig, main, maskRpcUrl };
+module.exports = { loadConfig, main };

--- a/scripts/mainnet/check-timelock-config.js
+++ b/scripts/mainnet/check-timelock-config.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const { ethers } = require("ethers");
+const { createRpcProvider, loadRpcConfig, sanitizeRpcError } = require("./lib/rpc-provider");
 
 const TIMELOCK_ABI = [
   "function getMinDelay() view returns (uint256)",
@@ -54,28 +55,10 @@ function checkedAddress(value, name) {
   }
 }
 
-function maskRpcUrl(value) {
-  try {
-    const url = new URL(value);
-    return `${url.protocol}//${url.host}/***`;
-  } catch (_) {
-    return "<masked-invalid-url>";
-  }
-}
-
 function loadConfig(env = process.env) {
   for (const name of REQUIRED_ENV) requiredValue(env, name);
 
-  const rpcUrl = requiredValue(env, "TIMELOCK_RPC_URL");
-  let parsedRpc;
-  try {
-    parsedRpc = new URL(rpcUrl);
-  } catch (_) {
-    throw new Error("TIMELOCK_RPC_URL must be a valid HTTP(S) URL");
-  }
-  if (!/^https?:$/.test(parsedRpc.protocol)) {
-    throw new Error("TIMELOCK_RPC_URL must use HTTP or HTTPS");
-  }
+  const rpc = loadRpcConfig(env, "TIMELOCK_RPC_URL", { requireHttps: false });
 
   const allowValue = String(env.ALLOW_DEPLOYER_TIMELOCK_ADMIN || "0").trim();
   if (!/^[01]$/.test(allowValue)) {
@@ -96,7 +79,8 @@ function loadConfig(env = process.env) {
   }
 
   return {
-    rpcUrl,
+    rpcUrl: rpc.rpcUrl,
+    rpcConfig: rpc,
     expectedChainId: positiveInteger(requiredValue(env, "EXPECTED_CHAIN_ID"), "EXPECTED_CHAIN_ID"),
     timelockAddress,
     expectedMinDelay: nonNegativeInteger(requiredValue(env, "EXPECTED_MIN_DELAY"), "EXPECTED_MIN_DELAY"),
@@ -108,10 +92,11 @@ function loadConfig(env = process.env) {
 
 async function main() {
   const config = loadConfig();
-  console.log(`RPC: ${maskRpcUrl(config.rpcUrl)}`);
+  console.log(`RPC: ${config.rpcConfig.rpcMasked}`);
+  console.log(`Auth mode: ${config.rpcConfig.authMode}; auth provided: ${config.rpcConfig.authProvided}`);
   console.log("Timelock admin role model: OpenZeppelin v5 DEFAULT_ADMIN_ROLE (bytes32(0)); no TIMELOCK_ADMIN_ROLE() getter.");
 
-  const provider = new ethers.JsonRpcProvider(config.rpcUrl, config.expectedChainId, { batchMaxCount: 1 });
+  const provider = createRpcProvider(config.rpcConfig, config.expectedChainId);
   const network = await provider.getNetwork();
   if (network.chainId !== config.expectedChainId) {
     throw new Error(`Chain ID mismatch: expected ${config.expectedChainId}, received ${network.chainId}`);
@@ -160,9 +145,9 @@ async function main() {
 
 if (require.main === module) {
   main().catch((error) => {
-    console.error(`FAIL: ${error.message.replace(/https?:\/\/[^\s)]+/gi, "<masked-rpc-url>")}`);
+    console.error(`FAIL: ${sanitizeRpcError(error)}`);
     process.exit(1);
   });
 }
 
-module.exports = { loadConfig, main, maskRpcUrl, ROLE_HASHES };
+module.exports = { loadConfig, main, ROLE_HASHES };

--- a/scripts/mainnet/deploy-timelock.js
+++ b/scripts/mainnet/deploy-timelock.js
@@ -12,6 +12,7 @@
 const fs = require("fs");
 const path = require("path");
 const { ethers } = require("ethers");
+const { createRpcProvider, loadRpcConfig, sanitizeRpcError } = require("./lib/rpc-provider");
 
 const ARC_MAINNET_CHAIN_ID = 5042n;
 const REQUIRED_MIN_DELAY = 172800n;
@@ -69,19 +70,12 @@ function exactUnsignedInteger(value, expected, name) {
   return parsed;
 }
 
-function checkedRpcUrl(value) {
-  let parsed;
-  try {
-    parsed = new URL(value);
-  } catch (_) {
-    throw new Error("MAINNET_RPC_URL must be a valid HTTPS URL");
-  }
-  if (parsed.protocol !== "https:") throw new Error("MAINNET_RPC_URL must use HTTPS");
-  if (parsed.username || parsed.password) throw new Error("MAINNET_RPC_URL must not contain URL user credentials");
-  if (RADAR_PATTERN.test(value) || RADAR_PATTERN.test(parsed.hostname)) {
+function checkedRpcUrl(value, env = process.env) {
+  const rpc = loadRpcConfig({ ...env, MAINNET_RPC_URL: value }, "MAINNET_RPC_URL", { requireHttps: true });
+  if (RADAR_PATTERN.test(rpc.rpcUrl) || RADAR_PATTERN.test(rpc.parsed.hostname)) {
     throw new Error("MAINNET_RPC_URL identifies Radar/read-only fallback infrastructure and is not deploy-grade");
   }
-  return value;
+  return rpc;
 }
 
 function checkedPrivateKey(value) {
@@ -91,22 +85,15 @@ function checkedPrivateKey(value) {
   return value;
 }
 
-function maskRpcUrl(value) {
-  try {
-    const url = new URL(value);
-    return `${url.protocol}//${url.host}/***`;
-  } catch (_) {
-    return "<masked-invalid-url>";
-  }
-}
-
 function loadConfig(env = process.env) {
   const dryRunValue = String(env.TIMELOCK_DEPLOY_DRY_RUN || "0").trim();
   if (!/^[01]$/.test(dryRunValue)) throw new Error("TIMELOCK_DEPLOY_DRY_RUN must be 0 or 1");
   const dryRun = dryRunValue === "1";
 
-  const rpcUrl = checkedRpcUrl(requiredValue(env, "MAINNET_RPC_URL"));
-  const privateKey = checkedPrivateKey(requiredValue(env, "PRIVATE_KEY"));
+  const rpc = checkedRpcUrl(requiredValue(env, "MAINNET_RPC_URL"), env);
+  // A dry run must be usable without loading or handling a private key. The
+  // key is required only after all write-mode confirmations are present.
+  const privateKey = dryRun ? undefined : checkedPrivateKey(requiredValue(env, "PRIVATE_KEY"));
   const expectedChainId = exactUnsignedInteger(
     requiredValue(env, "EXPECTED_CHAIN_ID"),
     ARC_MAINNET_CHAIN_ID,
@@ -125,6 +112,8 @@ function loadConfig(env = process.env) {
   let expectedDeployer;
   if (String(env.DEPLOYER_ADDRESS || "").trim()) {
     expectedDeployer = checkedAddress(requiredValue(env, "DEPLOYER_ADDRESS"), "DEPLOYER_ADDRESS");
+  } else if (dryRun) {
+    throw new Error("DEPLOYER_ADDRESS is required for dry-run preflight because PRIVATE_KEY is not used");
   }
 
   if (!dryRun) {
@@ -143,8 +132,12 @@ function loadConfig(env = process.env) {
     expectedDeployer,
     minDelay,
     privateKey,
-    rpcMasked: maskRpcUrl(rpcUrl),
-    rpcUrl,
+    rpcMasked: rpc.rpcMasked,
+    authMode: rpc.authMode,
+    authProvided: rpc.authProvided,
+    authMasked: rpc.authMasked,
+    rpcConfig: rpc,
+    rpcUrl: rpc.rpcUrl,
   };
 }
 
@@ -244,14 +237,14 @@ function writeArtifact(record) {
 
 async function main() {
   const config = loadConfig();
-  const artifact = loadArtifact();
-  const derivedDeployer = ethers.computeAddress(config.privateKey);
+  const artifact = config.dryRun ? undefined : loadArtifact();
+  const derivedDeployer = config.dryRun ? config.expectedDeployer : ethers.computeAddress(config.privateKey);
   if (config.expectedDeployer && derivedDeployer !== config.expectedDeployer) {
     throw new Error(`PRIVATE_KEY derives ${derivedDeployer}, not DEPLOYER_ADDRESS ${config.expectedDeployer}`);
   }
 
   // Disable JSON-RPC batching for predictable ceremony reads.
-  const provider = new ethers.JsonRpcProvider(config.rpcUrl, config.expectedChainId, { batchMaxCount: 1 });
+  const provider = createRpcProvider(config.rpcConfig, config.expectedChainId);
   await runReadOnlyPreflight(config, provider, derivedDeployer);
 
   const constructorArgs = [config.minDelay, [config.adminSafe], [config.adminSafe], ethers.ZeroAddress];
@@ -311,6 +304,8 @@ async function main() {
       admin: ethers.ZeroAddress,
     },
     rpcMasked: config.rpcMasked,
+    authMode: config.authMode,
+    authProvided: config.authProvided,
     verificationStatus: "TBD",
   };
   writeArtifact(record);
@@ -319,9 +314,7 @@ async function main() {
 
 if (require.main === module) {
   main().catch((error) => {
-    const message = String(error && error.message ? error.message : error)
-      .replace(/https?:\/\/[^\s)]+/gi, "<masked-rpc-url>");
-    console.error(`FAIL: ${message}`);
+    console.error(`FAIL: ${sanitizeRpcError(error)}`);
     process.exit(1);
   });
 }
@@ -332,5 +325,4 @@ module.exports = {
   RPC_CONFIRMATION,
   loadConfig,
   main,
-  maskRpcUrl,
 };

--- a/scripts/mainnet/lib/rpc-provider.js
+++ b/scripts/mainnet/lib/rpc-provider.js
@@ -1,0 +1,107 @@
+"use strict";
+
+const { ethers } = require("ethers");
+
+const PLACEHOLDER_PATTERN = /^(?:tbd|todo|null|undefined|placeholder|changeme|replace[_-]?me|example|your(?:[_-].*)?|<[^>]*>)$/i;
+const AUTH_MODES = new Set(["none", "bearer", "x-api-key", "custom"]);
+
+function value(env, name) {
+  return String(env[name] || "").trim();
+}
+
+function rejectPlaceholder(input, name) {
+  if (!input || PLACEHOLDER_PATTERN.test(input)) {
+    throw new Error(`${name} must not be empty or a placeholder`);
+  }
+  return input;
+}
+
+function maskSecret(input) {
+  if (!input) return undefined;
+  return "***";
+}
+
+function maskRpcUrl(input) {
+  try {
+    const url = new URL(input);
+    url.username = "";
+    url.password = "";
+    url.pathname = url.pathname === "/" ? "/***" : "/***";
+    if (url.search) url.search = "?***=masked";
+    url.hash = "";
+    return url.toString().replace(/\/$/, "");
+  } catch (_) {
+    return "<masked-invalid-rpc-url>";
+  }
+}
+
+function sanitizeRpcError(error, env = process.env) {
+  let message = String(error?.shortMessage || error?.message || error || "unknown error")
+    .replace(/https?:\/\/[^\s)\]}]+/gi, "<masked-rpc-url>");
+  for (const name of ["RPC_BEARER_TOKEN", "RPC_X_API_KEY", "RPC_AUTH_HEADER_VALUE"]) {
+    const secret = value(env, name);
+    if (secret) message = message.split(secret).join("***");
+  }
+  return message;
+}
+
+function checkedHeaderValue(input, name) {
+  const headerValue = rejectPlaceholder(input, name);
+  if (/[\r\n]/.test(headerValue)) throw new Error(`${name} must not contain newline characters`);
+  return headerValue;
+}
+
+function loadRpcConfig(env = process.env, urlName = "RPC_URL", { requireHttps = true } = {}) {
+  const rpcUrl = rejectPlaceholder(value(env, urlName), urlName);
+  let parsed;
+  try {
+    parsed = new URL(rpcUrl);
+  } catch (_) {
+    throw new Error(`${urlName} must be a valid ${requireHttps ? "HTTPS" : "HTTP(S)"} URL`);
+  }
+  if (requireHttps ? parsed.protocol !== "https:" : !/^https?:$/.test(parsed.protocol)) {
+    throw new Error(`${urlName} must use ${requireHttps ? "HTTPS" : "HTTP or HTTPS"}`);
+  }
+  if (parsed.username || parsed.password) throw new Error(`${urlName} must not contain URL user credentials`);
+
+  const authMode = value(env, "RPC_AUTH_MODE") || "none";
+  if (!AUTH_MODES.has(authMode)) throw new Error("RPC_AUTH_MODE must be none, bearer, x-api-key, or custom");
+  let headerName;
+  let headerValue;
+  let authSecret;
+  if (authMode === "bearer") {
+    headerName = "Authorization";
+    authSecret = checkedHeaderValue(value(env, "RPC_BEARER_TOKEN"), "RPC_BEARER_TOKEN");
+    headerValue = `Bearer ${authSecret}`;
+  } else if (authMode === "x-api-key") {
+    headerName = "X-API-Key";
+    authSecret = checkedHeaderValue(value(env, "RPC_X_API_KEY"), "RPC_X_API_KEY");
+    headerValue = authSecret;
+  } else if (authMode === "custom") {
+    headerName = rejectPlaceholder(value(env, "RPC_AUTH_HEADER_NAME"), "RPC_AUTH_HEADER_NAME");
+    authSecret = checkedHeaderValue(value(env, "RPC_AUTH_HEADER_VALUE"), "RPC_AUTH_HEADER_VALUE");
+    headerValue = authSecret;
+    if (!/^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/.test(headerName)) throw new Error("RPC_AUTH_HEADER_NAME must be a valid HTTP header name");
+  }
+  if (authSecret && (rpcUrl.includes(authSecret) || decodeURIComponent(rpcUrl).includes(authSecret))) {
+    throw new Error(`${urlName} must not contain the configured RPC auth value`);
+  }
+  return {
+    rpcUrl,
+    rpcMasked: maskRpcUrl(rpcUrl),
+    authMode,
+    authProvided: authMode !== "none",
+    authMasked: authMode === "none" ? undefined : { headerName, headerValue: maskSecret(headerValue) },
+    headerName,
+    headerValue,
+    parsed,
+  };
+}
+
+function createRpcProvider(config, network, providerOptions = {}) {
+  const request = new ethers.FetchRequest(config.rpcUrl);
+  if (config.authProvided) request.setHeader(config.headerName, config.headerValue);
+  return new ethers.JsonRpcProvider(request, network, { ...providerOptions, batchMaxCount: 1 });
+}
+
+module.exports = { AUTH_MODES, createRpcProvider, loadRpcConfig, maskRpcUrl, maskSecret, sanitizeRpcError };


### PR DESCRIPTION
This PR adds safe authenticated RPC support for future deploy-grade RPC candidates.

Included:
- Adds scripts/mainnet/lib/rpc-provider.js.
- Updates assess-rpc-deploy-grade.js, deploy-timelock.js, check-safe-config.js, and check-timelock-config.js to use safe authenticated RPC handling.
- Supports auth modes:
  - none
  - bearer
  - x-api-key
  - custom
- Uses ethers v6 FetchRequest and JsonRpcProvider with batching disabled.
- Updates deploy infrastructure, Timelock readiness, deployment runbook, launch inputs, and security checklist docs.

Safety:
- Rejects URL credentials.
- Rejects placeholders and empty auth values.
- Rejects auth values embedded in RPC URLs.
- Rejects newline-containing auth header values.
- Masks RPC paths/query strings and auth values.
- Never logs raw auth tokens.
- Deployment artifacts, if written in a future approved ceremony, include only masked RPC/auth metadata.
- Radar remains NOT_APPROVED.
- deploy-timelock.js still rejects Radar.
- Timelock deployment remains NO-GO.

Not included:
- No Timelock deployment.
- No contract deployment.
- No frontend deployment.
- No subgraph deployment.
- No live on-chain write.
- No signing.
- No private key used.
- No eth_sendRawTransaction call.
- No contract verification submission.
- No ownership or role transfer.
- No root set/freeze/activation.
- No env, secret, key, API key, wallet material, or deployment artifact changes.

Validation:
- node --check passed for all affected scripts.
- git diff --check passed.
- Restricted terminology scans passed.
- Negative tests passed for missing auth values, URL credentials, auth masking, Radar rejection, and dry-run private-key isolation.

Remaining blockers:
- Approved deploy-grade RPC provider is still required.
- Provider provenance, ownership, limits, support/SLA, and redundancy remain unresolved.
- Timelock deployment remains NO-GO.
- Mainnet deployment remains NO-GO.