### PR TITLE
fix: improve resolve truth states and hero layout

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -243,16 +243,15 @@ select.arcns-select option {
   z-index: 1;
   width: min(1480px, calc(100vw - 96px));
   margin: 0 auto;
-  padding-top: 96px;
+  padding-top: 72px;
   min-height: calc(100vh - 64px);
 }
 
 .arcns-left-emblem {
-  position: absolute;
-  left: clamp(28px, 5vw, 92px);
-  top: 142px;
-  width: clamp(300px, 22vw, 430px);
-  height: clamp(300px, 22vw, 430px);
+  position: relative;
+  width: clamp(150px, 18vw, 260px);
+  height: clamp(150px, 18vw, 260px);
+  margin: 0 auto 12px;
   z-index: 2;
   pointer-events: none;
 }
@@ -305,7 +304,23 @@ select.arcns-select option {
   width: min(900px, 100%);
   margin: 0 auto;
   text-align: center;
-  padding-top: 28px;
+  padding-top: 0;
+}
+
+.arcns-resolve-emblem {
+  width: clamp(112px, 18vw, 190px);
+  height: clamp(112px, 18vw, 190px);
+  margin-bottom: 22px;
+  opacity: 0.72;
+}
+
+.arcns-resolve-emblem img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  filter:
+    drop-shadow(0 0 26px rgba(0, 212, 255, 0.28))
+    drop-shadow(0 0 64px rgba(37, 99, 255, 0.18));
 }
 
 .arcns-live-badge {
@@ -332,7 +347,7 @@ select.arcns-select option {
 }
 
 .arcns-hero-headline {
-  margin: 28px auto 0;
+  margin: 22px auto 0;
   max-width: 960px;
   font-family: var(--arcns-font-display);
   font-size: clamp(4rem, 6.15vw, 7rem);
@@ -344,12 +359,24 @@ select.arcns-select option {
 }
 
 .arcns-hero-subtitle {
-  margin: 28px auto 0;
+  margin: 20px auto 0;
   max-width: 760px;
   color: var(--arcns-text-secondary);
   font-size: clamp(1.14rem, 1.45vw, 1.55rem);
   line-height: 1.45;
   font-weight: 400;
+}
+
+.arcns-hero-disclaimer {
+  width: min(760px, 100%);
+  margin: 12px auto 0;
+  color: var(--arcns-text-secondary);
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.arcns-hero-disclaimer strong {
+  color: var(--arcns-teal);
 }
 
 .arcns-hero-subtitle strong {
@@ -370,7 +397,7 @@ select.arcns-select option {
   position: relative;
   z-index: 4;
   width: min(920px, calc(100vw - 48px));
-  margin: 38px auto 0;
+  margin: 24px auto 0;
   border-radius: 28px;
   padding: 8px;
   background:
@@ -725,8 +752,7 @@ select.arcns-select option {
 
 @media (max-width: 1180px) {
   .arcns-left-emblem {
-    opacity: 0.22;
-    left: -82px;
+    opacity: 0.72;
   }
 
   .arcns-lower-suite {
@@ -749,15 +775,32 @@ select.arcns-select option {
 @media (max-width: 900px) {
   .arcns-landing-inner {
     width: calc(100vw - 32px);
-    padding-top: 48px;
+    padding-top: 36px;
   }
 
   .arcns-left-emblem {
-    display: none;
+    width: clamp(112px, 28vw, 180px);
+    height: clamp(112px, 28vw, 180px);
+    margin-bottom: 10px;
+    opacity: 0.62;
   }
 
   .arcns-hero-headline {
     font-size: clamp(3rem, 11vw, 5rem);
+  }
+
+  .arcns-hero-subtitle {
+    margin-top: 16px;
+  }
+
+  .arcns-hero-disclaimer {
+    margin-top: 10px;
+    font-size: 0.8rem;
+    line-height: 1.45;
+  }
+
+  .arcns-hero-search {
+    margin-top: 18px;
   }
 
   .arcns-searchbar-shell {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -110,15 +110,15 @@ export default function HomePage() {
 
         <div className="arcns-landing-inner">
           <div className="arcns-left-emblem" aria-hidden="true">
-  <Image
-  src="/arcns/arcns-emblem.svg"
-  alt=""
-  width={520}
-  height={520}
-  priority
-  className="arcns-left-emblem-img"
-/>
-</div>
+            <Image
+              src="/arcns/arcns-emblem.svg"
+              alt=""
+              width={520}
+              height={520}
+              priority
+              className="arcns-left-emblem-img"
+            />
+          </div>
 
           <div className="arcns-hero-copy">
             <div className="arcns-live-badge">
@@ -136,9 +136,9 @@ export default function HomePage() {
               <br />
               Receive an ERC-721 name NFT for your selected registration period.
             </p>
-            <p className="mt-4 max-w-2xl text-sm leading-6 text-[var(--arcns-text-secondary)]">
-              ArcNS is an independent name service built on Arc Testnet. <strong>.circle</strong> is an
-              ArcNS testnet namespace and does not imply Circle endorsement, sponsorship, affiliation, or ownership.
+            <p className="arcns-hero-disclaimer">
+              Independent Arc Testnet app. <strong>.circle</strong> is an ArcNS testnet namespace; no Circle
+              affiliation or endorsement is implied.
             </p>
           </div>
 

--- a/frontend/src/app/resolve/ResolvePage.test.tsx
+++ b/frontend/src/app/resolve/ResolvePage.test.tsx
@@ -39,6 +39,36 @@ vi.mock("next/link", () => ({
 }));
 
 import { useReadContract } from "wagmi";
+import { parseResolveQuery } from "./page";
+
+describe("Resolve query validation", () => {
+  it("accepts and normalizes supported names", () => {
+    expect(parseResolveQuery("  Alice.ARC ")).toEqual({
+      label: "alice",
+      tld: "arc",
+      domain: "alice.arc",
+    });
+    expect(parseResolveQuery("alice.circle")).toEqual({
+      label: "alice",
+      tld: "circle",
+      domain: "alice.circle",
+    });
+  });
+
+  it.each(["", "-alice.arc", "alice-.arc", "ali_ce.arc"])(
+    "rejects malformed input %s",
+    input => expect(parseResolveQuery(input)).toEqual({ error: "invalid" }),
+  );
+
+  it.each(["alice", "a.b.arc", "alice..arc", ".arc"])(
+    "rejects multi-label input %s as unsupported subname syntax",
+    input => expect(parseResolveQuery(input)).toEqual({ error: "malformed" }),
+  );
+
+  it("rejects unsupported suffixes", () => {
+    expect(parseResolveQuery("alice.eth")).toEqual({ error: "unsupportedTld" });
+  });
+});
 
 // ─── Bug 2 — Resolve page state conflation ────────────────────────────────────
 //
@@ -57,9 +87,6 @@ describe("Bug 2 — Resolve page state conflation: unregistered name shows wrong
         if (args?.functionName === "nameExpires") {
           return { data: 0n, isLoading: false };
         }
-        if (args?.functionName === "owner") {
-          return { data: CONNECTED_WALLET, isLoading: false };
-        }
         return { data: undefined, isLoading: false };
       });
 
@@ -70,7 +97,7 @@ describe("Bug 2 — Resolve page state conflation: unregistered name shows wrong
 
       render(<ResolvePage />);
 
-      const input = screen.getByPlaceholderText(/alice\.arc/i);
+      const input = screen.getByPlaceholderText(/flowpay\.arc/i);
       const button = screen.getByRole("button", { name: /resolve/i });
 
       const { fireEvent } = await import("@testing-library/react");
@@ -78,8 +105,8 @@ describe("Bug 2 — Resolve page state conflation: unregistered name shows wrong
       fireEvent.click(button);
 
       await waitFor(() => {
-        const notRegisteredMsg = screen.queryByText(/Name not registered/i);
-        expect(notRegisteredMsg).not.toBeNull();
+        const notRegisteredMsgs = screen.queryAllByText(/Name not registered/i);
+        expect(notRegisteredMsgs.length).toBeGreaterThan(0);
       }, { timeout: 500 });
 
       // No write CTA should appear
@@ -130,7 +157,7 @@ async function renderAndResolve(opts: {
   const { default: ResolvePage } = await import("./page");
   const { unmount } = render(<ResolvePage />);
 
-  const input = screen.getByPlaceholderText(/alice\.arc/i);
+  const input = screen.getByPlaceholderText(/flowpay\.arc/i);
   const button = screen.getByRole("button", { name: /resolve/i });
   fireEvent.change(input, { target: { value: "alice.arc" } });
   fireEvent.click(button);
@@ -155,7 +182,7 @@ describe("Preservation — Resolve page: registered-name behaviors for expiryTs 
       });
 
       await waitFor(() => {
-        const addrDisplay = screen.queryByText(NON_ZERO_ADDR);
+        const addrDisplay = screen.queryByText(/0x12345678…34567890/i);
         expect(addrDisplay).not.toBeNull();
       }, { timeout: 1000 });
 
@@ -181,15 +208,11 @@ describe("Preservation — Resolve page: registered-name behaviors for expiryTs 
       });
 
       await waitFor(() => {
-        expect(screen.queryByText(/No receiving address set/i)).not.toBeNull();
+        expect(screen.queryByText(/No forward address set/i)).not.toBeNull();
       }, { timeout: 1000 });
 
       // New model: guidance message shown, no write button
-      const guidance = screen.queryByText(/Set this name as your Primary Name/i);
-      expect(guidance).not.toBeNull();
-
-      const myDomainsLink = screen.queryByText(/Go to My Domains/i);
-      expect(myDomainsLink).not.toBeNull();
+      expect(screen.queryByText(/Connected wallet owns this name/i)).not.toBeNull();
 
       // No write button
       const writeBtn = screen.queryByRole("button", { name: /Set to connected wallet/i });
@@ -213,11 +236,11 @@ describe("Preservation — Resolve page: registered-name behaviors for expiryTs 
       });
 
       await waitFor(() => {
-        expect(screen.queryByText(/No receiving address set/i)).not.toBeNull();
+        expect(screen.queryByText(/No forward address set/i)).not.toBeNull();
       }, { timeout: 1000 });
 
       // No guidance for non-owner
-      expect(screen.queryByText(/Set this name as your Primary Name/i)).toBeNull();
+      expect(screen.queryByText(/Connected wallet does not own this name/i)).not.toBeNull();
       expect(screen.queryByRole("button", { name: /Set to connected wallet/i })).toBeNull();
 
       unmount();
@@ -248,8 +271,8 @@ describe("Preservation — Resolve page: registered-name behaviors for expiryTs 
           let guidanceShown = false;
 
           await waitFor(() => {
-            noAddrShown = screen.queryByText(/No receiving address set/i) !== null;
-            guidanceShown = screen.queryByText(/Set this name as your Primary Name/i) !== null;
+            noAddrShown = screen.queryByText(/No forward address set/i) !== null;
+            guidanceShown = screen.queryByText(/Connected wallet owns this name/i) !== null;
             if (!noAddrShown || !guidanceShown) throw new Error("not yet");
           }, { timeout: 1000 }).catch(() => {});
 
@@ -287,14 +310,14 @@ describe("Preservation — Resolve page: registered-name behaviors for expiryTs 
           let noAddrShown = false;
 
           await waitFor(() => {
-            noAddrShown = screen.queryByText(/No receiving address set/i) !== null;
+            noAddrShown = screen.queryByText(/No forward address set/i) !== null;
             if (!noAddrShown) throw new Error("not yet");
           }, { timeout: 1000 }).catch(() => {});
 
           const ctaAbsent =
             screen.queryByRole("button", { name: /Set to connected wallet/i }) === null;
           const guidanceAbsent =
-            screen.queryByText(/Set this name as your Primary Name/i) === null;
+            screen.queryByText(/Connected wallet owns this name/i) === null;
 
           unmount();
           cleanup();

--- a/frontend/src/app/resolve/page.tsx
+++ b/frontend/src/app/resolve/page.tsx
@@ -45,15 +45,29 @@ import { CopyButton } from "../../components/ui/CopyButton";
 import { TldBadge } from "../../components/ui/TldBadge";
 import { FooterIdentityLine } from "../../components/ui/FooterIdentityLine";
 
+export type ResolveQuery = { label: string; tld: SupportedTLD; domain: string };
+export type ResolveInputState = "pristine" | "invalid" | "malformed" | "unsupportedTld" | "valid";
+
+/** Resolve accepts exactly one ASCII label plus one supported suffix. */
+export function parseResolveQuery(raw: string): ResolveQuery | { error: Exclude<ResolveInputState, "pristine" | "valid"> } {
+  const value = raw.trim().toLowerCase();
+  if (!value) return { error: "invalid" };
+  const parts = value.split(".");
+  if (parts.length !== 2 || !parts[0]) return { error: "malformed" };
+  if (parts[1] !== "arc" && parts[1] !== "circle") return { error: "unsupportedTld" };
+  if (!isValidLabel(parts[0])) return { error: "invalid" };
+  return { label: parts[0], tld: parts[1], domain: `${parts[0]}.${parts[1]}` };
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Forward resolution hook — preserved
 // ─────────────────────────────────────────────────────────────────────────────
 
-function useResolveAddress(domain: string) {
+function useResolveAddress(domain: string, enabled: boolean, retryKey: number) {
   const node = namehash(domain);
-  const enabled = domain.includes(".");
   const [data, setData] = useState<string | undefined>(undefined);
   const [isLoading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
 
   useEffect(() => {
     if (!enabled) {
@@ -63,6 +77,7 @@ function useResolveAddress(domain: string) {
 
     let cancelled = false;
     setLoading(true);
+    setError(false);
 
     import("../../lib/publicClient").then(({ publicClient }) => {
       publicClient
@@ -81,6 +96,7 @@ function useResolveAddress(domain: string) {
         .catch(() => {
           if (!cancelled) {
             setData(undefined);
+            setError(true);
             setLoading(false);
           }
         });
@@ -89,9 +105,9 @@ function useResolveAddress(domain: string) {
     return () => {
       cancelled = true;
     };
-  }, [domain, node, enabled]);
+  }, [domain, node, enabled, retryKey]);
 
-  return { data, isLoading };
+  return { data, isLoading, isError: error };
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -321,7 +337,7 @@ function DetailRow({
   explorerHref?: string;
 }) {
   return (
-    <div className="grid grid-cols-[150px_1fr] items-center gap-4 py-2">
+    <div className="grid grid-cols-1 gap-1 py-2 sm:grid-cols-[150px_1fr] sm:items-center sm:gap-4">
       <p className="text-sm" style={{ color: "var(--arcns-text-muted)" }}>
         {label}
       </p>
@@ -400,24 +416,31 @@ function RecordPill({
 export default function ResolvePage() {
   const [domain, setDomain] = useState("");
   const [queried, setQueried] = useState("");
+  const [queryError, setQueryError] = useState<"invalid" | "malformed" | "unsupportedTld" | null>(null);
+  const [retryKey, setRetryKey] = useState(0);
+
+  const parsedQuery = parseResolveQuery(queried);
+  const validQuery = "domain" in parsedQuery ? parsedQuery : null;
 
   const { address: connectedAddress } = useAccount();
-  const { data: resolvedAddr, isLoading } = useResolveAddress(queried);
+  const { data: resolvedAddr, isLoading, isError: addressError } = useResolveAddress(
+    validQuery?.domain ?? "",
+    !!validQuery,
+    retryKey,
+  );
 
-  const parts = queried.split(".");
-  const label = parts[0] ?? "";
-  const rawTld = parts[1] ?? "";
-  const tld = rawTld === "arc" || rawTld === "circle" ? (rawTld as SupportedTLD) : null;
+  const label = validQuery?.label ?? "";
+  const tld = validQuery?.tld ?? null;
   const registrar = tld === "circle" ? ADDR_CIRCLE_REGISTRAR : ADDR_ARC_REGISTRAR;
   const tokenId = label ? labelToTokenId(label) : 0n;
 
-  const { data: expiry, isPending: expiryLoading } = useReadContract({
+  const { data: expiry, isPending: expiryLoading, isError: expiryError, refetch: refetchExpiry } = useReadContract({
     address: registrar as `0x${string}`,
     abi: REGISTRAR_ABI,
     functionName: "nameExpires",
     args: [tokenId],
     query: {
-      enabled: !!tld && isValidLabel(label),
+      enabled: !!validQuery,
       staleTime: 30_000,
       refetchOnWindowFocus: false,
     },
@@ -427,11 +450,20 @@ export default function ResolvePage() {
   const expiryState = getExpiryState(expiryTs);
   const badge = expiryBadge(expiryState);
 
-  const handleResolve = () => setQueried(domain.trim().toLowerCase());
+  const handleResolve = () => {
+    const result = parseResolveQuery(domain);
+    if ("error" in result) {
+      setQueryError(result.error);
+      setQueried("");
+      return;
+    }
+    setQueryError(null);
+    setQueried(result.domain);
+  };
 
   const nodeBytes = queried ? (namehash(queried) as `0x${string}`) : undefined;
   const node = queried ? namehash(queried) : "";
-  const hasResult = !!queried && queried.includes(".");
+  const hasResult = !!validQuery;
   const addr = resolvedAddr as string | undefined;
 
   // Forward resolution: only true when a valid non-zero address is returned.
@@ -439,13 +471,13 @@ export default function ResolvePage() {
     !!addr && addr !== "0x0000000000000000000000000000000000000000" ? addr : undefined;
   const hasAddr = !!normalizedResolvedAddress;
 
-  const { data: ownerData, isPending: ownerLoading } = useReadContract({
+  const { data: ownerData, isPending: ownerLoading, isError: ownerError, refetch: refetchOwner } = useReadContract({
     ...REGISTRY_CONTRACT,
     functionName: "owner",
     args: nodeBytes ? [nodeBytes] : undefined,
     query: {
       // Public read — no wallet required. Enable whenever a valid domain is queried.
-      enabled: !!queried && queried.includes("."),
+      enabled: !!validQuery,
       staleTime: 30_000,
       refetchOnWindowFocus: false,
     },
@@ -454,14 +486,14 @@ export default function ResolvePage() {
   // registry.owner(node) returns the registrar contract address for registered
   // second-level names — not the user's wallet. The actual NFT holder is
   // tracked by registrar.ownerOf(tokenId). We read both and prefer ownerOf.
-  const { data: registrarOwnerData, isPending: registrarOwnerLoading } = useReadContract({
+  const { data: registrarOwnerData, isPending: registrarOwnerLoading, isError: registrarOwnerError, refetch: refetchRegistrarOwner } = useReadContract({
     address: registrar as `0x${string}`,
     abi: REGISTRAR_ABI,
     functionName: "ownerOf",
     args: [tokenId],
     query: {
       // ownerOf reverts for non-existent/expired tokens — wagmi returns undefined on revert.
-      enabled: !!tld && isValidLabel(label) && tokenId > 0n,
+      enabled: !!validQuery && tokenId > 0n,
       staleTime: 30_000,
       refetchOnWindowFocus: false,
       retry: false, // don't retry reverts
@@ -498,16 +530,13 @@ export default function ResolvePage() {
   // resolved address. Absence of a forward record ≠ unregistered.
   const hasOwner = !!ownerAddress;
   const hasExpiry = expiryTs > 0n;
-  const now = BigInt(Math.floor(Date.now() / 1000));
-  const isExpired = hasExpiry && expiryTs <= now;
-
   // Only conclude "unregistered" once all reads have settled and none
   // returned ownership or expiry data.
   const readsSettled =
     hasResult && !isLoading && !expiryLoading && !ownerLoading && !registrarOwnerLoading;
+  const readError = addressError || expiryError || ownerError || registrarOwnerError;
   const isRegistered = hasOwner || hasExpiry;
-  const isUnregistered = readsSettled && !isRegistered;
-  const isActive = isRegistered && !isExpired;
+  const isUnregistered = readsSettled && !readError && !isRegistered;
 
   const explorerTokenHref =
     tld && label
@@ -521,6 +550,12 @@ export default function ResolvePage() {
   const ownerExplorerHref = ownerAddress
     ? `https://testnet.arcscan.app/address/${ownerAddress}`
     : undefined;
+
+  const ownershipCopy = !connectedAddress
+    ? "Connect wallet to compare ownership."
+    : isOwner
+      ? "Connected wallet owns this name."
+      : "Connected wallet does not own this name.";
 
   return (
     <div
@@ -540,11 +575,11 @@ export default function ResolvePage() {
         }}
       />
 
-      <main className="relative z-10 mx-auto w-[min(1280px,calc(100vw-96px))] py-14">
+      <main className="relative z-10 mx-auto w-full max-w-[1044px] px-4 py-10 sm:px-6 lg:px-8 lg:py-14">
         {/* Hero */}
         <section className="relative mb-7 min-h-[245px]">
           <div
-            className="pointer-events-none absolute left-[-76px] top-[-18px] hidden h-[260px] w-[300px] items-center justify-center lg:flex"
+            className="arcns-resolve-emblem pointer-events-none mx-auto flex items-center justify-center"
             aria-hidden="true"
           >
             <Image
@@ -562,7 +597,7 @@ export default function ResolvePage() {
             />
           </div>
 
-          <div className="relative z-10 ml-0 pt-7 lg:ml-[220px]">
+          <div className="relative z-10 text-center">
             <h1
               className="text-[clamp(3rem,6vw,5.5rem)] font-bold leading-[0.95] tracking-[-0.075em]"
               style={{
@@ -574,14 +609,14 @@ export default function ResolvePage() {
               Resolve
             </h1>
             <p
-              className="mt-5 max-w-[760px] text-2xl leading-relaxed"
+              className="mx-auto mt-5 max-w-[760px] text-2xl leading-relaxed"
               style={{ color: "var(--arcns-text-secondary)" }}
             >
               Inspect any ArcNS name and its on-chain identity records.
             </p>
 
             <section
-              className="relative mt-8 max-w-[980px] overflow-hidden rounded-[28px] border p-5"
+              className="relative mt-8 w-full overflow-hidden rounded-[28px] border p-4 sm:p-5"
               style={{
                 background:
                   "linear-gradient(180deg, rgba(11,18,36,0.82), rgba(8,14,31,0.76))",
@@ -611,6 +646,7 @@ export default function ResolvePage() {
                     className="min-w-0 flex-1 bg-transparent text-lg font-semibold outline-none"
                     style={{ color: "var(--arcns-text-primary)" }}
                     aria-label="Enter an ArcNS name to resolve"
+                    aria-describedby="resolve-feedback"
                   />
 
                   {tld ? (
@@ -637,8 +673,9 @@ export default function ResolvePage() {
                 </label>
 
                 <button
+                  type="button"
                   onClick={handleResolve}
-                  className="h-16 rounded-[var(--arcns-radius-lg)] px-10 text-lg font-bold text-white transition-all duration-150 hover:translate-y-[-1px] hover:opacity-95 active:scale-[0.98]"
+                  className="arcns-focus-ring h-16 rounded-[var(--arcns-radius-lg)] px-10 text-lg font-bold text-white transition-all duration-150 hover:translate-y-[-1px] hover:opacity-95 active:scale-[0.98]"
                   style={{
                     background: "var(--arcns-gradient-primary)",
                     boxShadow: "0 18px 45px rgba(37,99,255,0.30)",
@@ -647,13 +684,18 @@ export default function ResolvePage() {
                   Resolve
                 </button>
               </div>
+              <div id="resolve-feedback" className="mt-3 text-sm" role="status" aria-live="polite">
+                {queryError === "unsupportedTld" ? "Use a name ending in .arc or .circle." : null}
+                {queryError === "malformed" ? "Use one name label before .arc or .circle. Subnames are not supported here yet." : null}
+                {queryError === "invalid" ? "Only letters, numbers, hyphens, and underscores are allowed." : null}
+              </div>
             </section>
           </div>
         </section>
 
         {!hasResult ? (
           <section
-            className="mx-auto mt-10 max-w-[900px] rounded-[28px] border px-8 py-10 text-center"
+            className="mt-10 w-full rounded-[28px] border px-5 py-10 text-center sm:px-8"
             style={{
               background:
                 "linear-gradient(180deg, rgba(11,18,36,0.64), rgba(8,14,31,0.56))",
@@ -707,8 +749,23 @@ export default function ResolvePage() {
           </section>
         ) : null}
 
-        {hasResult ? (
-          <section className="space-y-6">
+        {hasResult && !readsSettled ? (
+          <section className="mt-10 w-full rounded-[28px] border px-5 py-10 text-center sm:px-8" role="status" aria-live="polite" aria-busy="true" style={{ background: "rgba(11,18,36,0.72)", borderColor: "rgba(120,160,255,0.20)" }}>
+            <h2 className="text-2xl font-bold" style={{ color: "var(--arcns-text-primary)" }}>Verifying {queried}…</h2>
+            <p className="mt-3 text-sm" style={{ color: "var(--arcns-text-secondary)" }}>Reading Arc testnet records.</p>
+          </section>
+        ) : null}
+
+        {hasResult && readsSettled && readError ? (
+          <section className="mt-10 w-full rounded-[28px] border px-5 py-10 text-center sm:px-8" role="alert" aria-live="assertive" style={{ background: "rgba(11,18,36,0.72)", borderColor: "rgba(255,92,122,0.28)" }}>
+            <h2 className="text-2xl font-bold" style={{ color: "var(--arcns-text-primary)" }}>We could not verify this name right now.</h2>
+            <p className="mt-3 text-sm" style={{ color: "var(--arcns-text-secondary)" }}>This does not mean the name is unregistered.</p>
+            <button type="button" onClick={() => { setRetryKey(key => key + 1); void refetchExpiry(); void refetchOwner(); void refetchRegistrarOwner(); }} className="arcns-focus-ring mt-6 rounded-[var(--arcns-radius-lg)] px-6 py-3 text-sm font-bold text-white" style={{ background: "var(--arcns-gradient-primary)" }}>Try again</button>
+          </section>
+        ) : null}
+
+        {hasResult && readsSettled && !readError ? (
+          <section className="space-y-6" role="status" aria-live="polite">
             {/* Main overview card */}
             <div
               className="grid gap-0 overflow-hidden rounded-[28px] border lg:grid-cols-[150px_1fr_250px]"
@@ -777,7 +834,9 @@ export default function ResolvePage() {
                         ? "Loading..."
                         : hasAddr
                           ? shortAddress(normalizedResolvedAddress!, 10, 8)
-                          : "No address record"
+                          : isUnregistered
+                            ? "No address record"
+                            : "Unavailable until reads settle"
                     }
                     valueColor={
                       hasAddr
@@ -790,7 +849,7 @@ export default function ResolvePage() {
 
                   <DetailRow
                     label="Owner"
-                    value={ownerAddress ? shortAddress(ownerAddress, 8, 6) : "Owner not available"}
+                    value={ownerAddress ? shortAddress(ownerAddress, 8, 6) : isUnregistered ? "Owner record not found" : "Unavailable until reads settle"}
                     valueColor={ownerAddress ? "var(--arcns-cyan)" : "var(--arcns-text-muted)"}
                     copyValue={ownerAddress}
                     explorerHref={ownerExplorerHref}
@@ -817,8 +876,8 @@ export default function ResolvePage() {
                         ? "Loading..."
                         : expiryTs > 0n
                           ? formatExpiry(expiryTs)
-                          : isUnregistered
-                            ? "Not registered"
+                        : isUnregistered
+                            ? "Name not registered"
                             : "—"
                     }
                     valueColor={
@@ -924,7 +983,7 @@ export default function ResolvePage() {
                     style={{ color: hasAddr ? "var(--arcns-green)" : "var(--arcns-text-muted)" }}
                   >
                     {hasAddr ? <StatusDot /> : null}
-                    {hasAddr ? "Resolved" : "Not set"}
+                    {hasAddr ? "Resolved address found" : "No forward address set"}
                   </span>
                 </div>
 
@@ -944,7 +1003,7 @@ export default function ResolvePage() {
                     style={{ color: hasAddr ? "var(--arcns-text-primary)" : "var(--arcns-text-muted)" }}
                     title={hasAddr ? normalizedResolvedAddress : undefined}
                   >
-                    {hasAddr ? shortAddress(normalizedResolvedAddress!, 12, 10) : "No address record"}
+                    {hasAddr ? shortAddress(normalizedResolvedAddress!, 12, 10) : isUnregistered ? "No address record" : "Unavailable until reads settle"}
                   </p>
 
                   {hasAddr ? <CopyButton value={normalizedResolvedAddress!} aria-label="Copy resolved address" /> : null}
@@ -1003,7 +1062,7 @@ export default function ResolvePage() {
                     style={{ color: ownerAddress ? "var(--arcns-green)" : "var(--arcns-text-muted)" }}
                   >
                     {ownerAddress ? <StatusDot /> : null}
-                    {ownerAddress ? "Verified" : "Unknown"}
+                    {ownerAddress ? "Owner record found" : "Owner record not found"}
                   </span>
                 </div>
 
@@ -1029,7 +1088,7 @@ export default function ResolvePage() {
                   {ownerAddress ? <CopyButton value={ownerAddress} aria-label="Copy owner address" /> : null}
                 </div>
 
-                <div className="mt-5 flex items-center justify-between">
+                <div className="mt-5 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                   <p className="text-sm" style={{ color: "var(--arcns-text-muted)" }}>
                     Connected wallet
                   </p>
@@ -1041,7 +1100,7 @@ export default function ResolvePage() {
                       color: isOwner ? "var(--arcns-green)" : "var(--arcns-text-muted)",
                     }}
                   >
-                    {isOwner ? "Owner" : "Not owner / unknown"}
+                    {ownershipCopy}
                   </span>
                 </div>
               </div>
@@ -1096,7 +1155,7 @@ export default function ResolvePage() {
                         : expiryTs > 0n
                           ? formatExpiry(expiryTs)
                           : isUnregistered
-                            ? "Not registered"
+                            ? "Name not registered"
                             : "—"}
                     </p>
                   </div>
@@ -1116,7 +1175,7 @@ export default function ResolvePage() {
                       }
                     >
                       {isUnregistered
-                        ? "Not registered"
+                        ? "Name not registered"
                         : isRegistered
                           ? badge.label
                           : "Loading…"}


### PR DESCRIPTION
This PR improves the Resolve page validation/state model and fixes hero layout overlap issues.

Included:
- Adds one validated Resolve query model for `.arc` and `.circle` names.
- Rejects malformed multi-label inputs such as `a.b.arc`, `alice..arc`, and `.arc` with clearer copy.
- Keeps unsupported TLDs such as `alice.eth` separate from malformed or invalid-character errors.
- Gates Resolve reads behind the same validated query model.
- Separates RPC/read failures from genuine unregistered/no-address states.
- Adds non-authoritative read-error copy and retry behavior.
- Improves Resolve ownership wording for disconnected, owner, and non-owner wallet states.
- Aligns Resolve search, empty, loading, error, and result containers on one responsive grid.
- Fixes Home and Resolve hero emblem/text overlap.
- Tightens Home hero spacing so the search/register box appears earlier.
- Updates focused Resolve tests.

Not included:
- No mainnet cutover.
- No contract address additions.
- No discount UI activation.
- No registerWithDiscount enablement.
- No pricing logic changes.
- No deployment script changes.
- No env, secret, wallet, API key, or deployment artifact changes.
- No SEO/internal/audit documents.

Validation:
- Targeted Resolve test passed: 16/16.
- Frontend lint passed with existing unrelated warnings.
- Frontend build passed.
- git diff --check passed.
- Restricted terminology scan passed.
- Full frontend test suite still has unrelated pre-existing failures outside this PR scope.

Manual QA:
- Home desktop checked.
- Resolve desktop checked.
- Home hero/logo overlap fixed.
- Resolve hero/logo overlap fixed.
- Search/register box positioning improved.