### PR TITLE
fix: polish core UI states and accessibility

### DIFF
--- a/frontend/src/app/my-domains/page.tsx
+++ b/frontend/src/app/my-domains/page.tsx
@@ -68,9 +68,11 @@ export default function MyDomainsPage() {
           key={t}
           type="button"
           role="tab"
+          id={`my-domains-tab-${t}`}
           aria-selected={active}
+          aria-controls={`my-domains-panel-${t}`}
           onClick={() => setTab(t)}
-          className="arcns-domains-tab"
+          className="arcns-domains-tab arcns-focus-ring"
           data-active={active ? "true" : "false"}
         >
           {t === "portfolio" ? "Portfolio" : "History"}
@@ -93,28 +95,25 @@ export default function MyDomainsPage() {
         </svg>
 
         <input
+          id="portfolio-search"
+          aria-label="Search your domains"
           value={portfolioSearch}
           onChange={event => setPortfolioSearch(event.target.value)}
           placeholder="Search your domains..."
         />
       </label>
 
-      <button type="button" className="arcns-domains-filter">
-        <svg width="16" height="16" viewBox="0 0 18 18" fill="none" aria-hidden="true">
-          <path
-            d="M3 4.5H15L10.5 9.6V13.5L7.5 15V9.6L3 4.5Z"
-            stroke="currentColor"
-            strokeWidth="1.5"
-            strokeLinejoin="round"
-          />
-        </svg>
-        Filter
-      </button>
     </div>
   ) : null}
 </section>
 
-        <section className="arcns-domains-content">
+        <section
+          id={`my-domains-panel-${tab}`}
+          role="tabpanel"
+          aria-labelledby={`my-domains-tab-${tab}`}
+          className="arcns-domains-content"
+          tabIndex={0}
+        >
           {tab === "portfolio" ? (
   <Portfolio searchQuery={portfolioSearch} />
 ) : (

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -29,6 +29,8 @@ function ChainGuardBanner() {
 
   return (
     <div
+      role="alert"
+      aria-live="assertive"
       style={{
         position: "fixed", top: 0, left: 0, right: 0, zIndex: 9999,
         background: "var(--color-error)", color: "#fff",

--- a/frontend/src/components/DomainCard.tsx
+++ b/frontend/src/components/DomainCard.tsx
@@ -465,18 +465,18 @@ export default function DomainCard({ label, tld, isCommitted = false }: DomainCa
       ) : nameState === "CHECKING" ? (
         checkPhase === 0 ? <div className="py-3" /> :
         checkPhase === 1 ? (
-          <div className="text-center py-3 text-sm rounded-[var(--arcns-radius-lg)]" style={{ background: 'var(--arcns-bg-elevated)', color: 'var(--arcns-text-muted)' }}>Validating…</div>
+          <div role="status" aria-live="polite" className="text-center py-3 text-sm rounded-[var(--arcns-radius-lg)]" style={{ background: 'var(--arcns-bg-elevated)', color: 'var(--arcns-text-muted)' }}>Validating…</div>
         ) : (
-          <div className="text-center py-3 text-sm rounded-[var(--arcns-radius-lg)] animate-pulse" style={{ background: 'rgba(37,99,255,0.08)', color: '#8FB3FF' }}>
+          <div role="status" aria-live="polite" className="text-center py-3 text-sm rounded-[var(--arcns-radius-lg)] animate-pulse" style={{ background: 'rgba(37,99,255,0.08)', color: '#8FB3FF' }}>
             Checking availability on Arc Testnet…
           </div>
         )
 
       ) : nameState === "AVAILABLE" ? (
         !isConnected ? (
-          <div className="text-center py-3 text-sm rounded-[var(--arcns-radius-lg)]" style={{ background: 'var(--arcns-bg-elevated)', color: 'var(--arcns-text-secondary)' }}>Connect wallet to register</div>
+          <div role="status" aria-live="polite" className="text-center py-3 text-sm rounded-[var(--arcns-radius-lg)]" style={{ background: 'var(--arcns-bg-elevated)', color: 'var(--arcns-text-secondary)' }}>Connect wallet to register. Use the Connect Wallet button in the header.</div>
         ) : isWrongNetwork ? (
-          <div className="text-center py-3 text-sm rounded-[var(--arcns-radius-lg)] font-medium" style={{ background: 'rgba(255,92,122,0.08)', color: 'var(--arcns-danger)' }}>
+          <div role="alert" aria-live="assertive" className="text-center py-3 text-sm rounded-[var(--arcns-radius-lg)] font-medium" style={{ background: 'rgba(255,92,122,0.08)', color: 'var(--arcns-danger)' }}>
             ⚠ Switch to Arc Testnet (Chain ID {DEPLOYED_CHAIN_ID}) to register
           </div>
         ) : isPriceLoading ? (
@@ -490,11 +490,11 @@ export default function DomainCard({ label, tld, isCommitted = false }: DomainCa
             className="w-full py-3.5 text-white rounded-[var(--arcns-radius-lg)] font-semibold disabled:opacity-40 disabled:cursor-not-allowed transition-all duration-150 hover:opacity-90 active:scale-[0.99] text-sm"
             style={{ background: 'var(--arcns-gradient-primary)' }}
           >
-            {reg.step === "approving"   ? "Approving USDC…"
-            : reg.step === "committing" ? "Submitting commitment…"
+            {reg.step === "approving"   ? "Confirm USDC approval in your wallet…"
+            : reg.step === "committing" ? "Confirm commitment in your wallet…"
             : reg.step === "waiting"    ? `Waiting… ${reg.waitProgress}%`
-            : reg.step === "ready"      ? "Ready to register…"
-            : reg.step === "registering"? "Registering on-chain…"
+            : reg.step === "ready"      ? "Commitment submitted · preparing registration…"
+            : reg.step === "registering"? "Confirm registration in your wallet…"
             : reg.step === "success"    ? "✓ Registered!"
             : `Register ${label}.${tld} · ${formatUSDC(totalCost)}`}
           </button>
@@ -503,9 +503,9 @@ export default function DomainCard({ label, tld, isCommitted = false }: DomainCa
       ) : /* TAKEN */ (
         expiryState === "active" || expiryState === "expiring-soon" || expiryState === "grace" ? (
           !isConnected ? (
-            <div className="text-center py-3 text-sm rounded-[var(--arcns-radius-lg)]" style={{ background: 'var(--arcns-bg-elevated)', color: 'var(--arcns-text-secondary)' }}>Connect wallet to renew</div>
+              <div role="status" aria-live="polite" className="text-center py-3 text-sm rounded-[var(--arcns-radius-lg)]" style={{ background: 'var(--arcns-bg-elevated)', color: 'var(--arcns-text-secondary)' }}>Connect wallet to renew. Use the Connect Wallet button in the header.</div>
           ) : isWrongNetwork ? (
-            <div className="text-center py-3 text-sm rounded-[var(--arcns-radius-lg)] font-medium" style={{ background: 'rgba(255,92,122,0.08)', color: 'var(--arcns-danger)' }}>
+            <div role="alert" aria-live="assertive" className="text-center py-3 text-sm rounded-[var(--arcns-radius-lg)] font-medium" style={{ background: 'rgba(255,92,122,0.08)', color: 'var(--arcns-danger)' }}>
               ⚠ Switch to Arc Testnet (Chain ID {DEPLOYED_CHAIN_ID}) to renew
             </div>
           ) : isOwnerLoading ? (
@@ -532,8 +532,8 @@ export default function DomainCard({ label, tld, isCommitted = false }: DomainCa
               className="w-full py-3.5 text-white rounded-[var(--arcns-radius-lg)] font-semibold disabled:opacity-50 transition-all duration-150 hover:opacity-90 active:scale-[0.99] text-sm"
               style={{ background: 'var(--arcns-warning)' }}
             >
-              {renew.step === "approving" ? "Approving USDC…"
-              : renew.step === "renewing" ? "Renewing…"
+              {renew.step === "approving" ? "Confirm USDC approval in your wallet…"
+              : renew.step === "renewing" ? "Confirm renewal in your wallet…"
               : renew.step === "success"  ? "✓ Renewed!"
               : isPriceLoading ? `Renew ${label}.${tld} · Loading…`
               : `Renew ${label}.${tld} · ${formatUSDC(totalCost)}`}
@@ -559,7 +559,7 @@ export default function DomainCard({ label, tld, isCommitted = false }: DomainCa
 
       {/* Error display */}
       {activeError ? (
-        <div className="mt-3 text-sm rounded-[var(--arcns-radius-lg)] p-3 flex items-start gap-2 border" style={{ background: 'rgba(255,92,122,0.08)', borderColor: 'rgba(255,92,122,0.24)', color: 'var(--arcns-danger)' }}>
+        <div role="alert" aria-live="assertive" className="mt-3 text-sm rounded-[var(--arcns-radius-lg)] p-3 flex items-start gap-2 border" style={{ background: 'rgba(255,92,122,0.08)', borderColor: 'rgba(255,92,122,0.24)', color: 'var(--arcns-danger)' }}>
           <span>⚠</span>
           <span>{activeError}</span>
         </div>
@@ -567,7 +567,7 @@ export default function DomainCard({ label, tld, isCommitted = false }: DomainCa
 
       {/* Success state */}
       {reg.step === "success" && reg.result ? (
-        <div className="mt-3 text-sm rounded-[var(--arcns-radius-lg)] p-3 flex items-start gap-2 border" style={{ background: 'rgba(20,241,149,0.08)', borderColor: 'rgba(20,241,149,0.24)', color: 'var(--arcns-green)' }}>
+        <div role="status" aria-live="polite" className="mt-3 text-sm rounded-[var(--arcns-radius-lg)] p-3 flex items-start gap-2 border" style={{ background: 'rgba(20,241,149,0.08)', borderColor: 'rgba(20,241,149,0.24)', color: 'var(--arcns-green)' }}>
           <span>✓</span>
           <div>
             <p className="font-medium">{reg.result.name}.{reg.result.tld} registered!</p>

--- a/frontend/src/components/Portfolio.tsx
+++ b/frontend/src/components/Portfolio.tsx
@@ -24,6 +24,7 @@ import { useRenew } from "../hooks/useRenew";
 import { useReceivingAddress } from "../hooks/useReceivingAddress";
 import { usePrimaryName } from "../hooks/usePrimaryName";
 import { namehash } from "../lib/namehash";
+import { CopyButton } from "./ui/CopyButton";
 import {
   formatExpiry,
   daysUntilExpiry,
@@ -82,28 +83,6 @@ function TldTile({ tld }: { tld: string }) {
   );
 }
 
-function CopyGlyph() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-      <rect
-        x="5"
-        y="5"
-        width="8"
-        height="8"
-        rx="1.5"
-        stroke="currentColor"
-        strokeWidth="1.4"
-      />
-      <path
-        d="M3 10.5H2.8C1.8 10.5 1 9.7 1 8.7V2.8C1 1.8 1.8 1 2.8 1H8.7C9.7 1 10.5 1.8 10.5 2.8V3"
-        stroke="currentColor"
-        strokeWidth="1.4"
-        strokeLinecap="round"
-      />
-    </svg>
-  );
-}
-
 function ShieldGlyph() {
   return (
     <svg width="17" height="17" viewBox="0 0 18 18" fill="none" aria-hidden="true">
@@ -139,24 +118,8 @@ function ClockGlyph() {
   );
 }
 
-function MoreGlyph() {
-  return (
-    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
-      <circle cx="4" cy="9" r="1.25" fill="currentColor" />
-      <circle cx="9" cy="9" r="1.25" fill="currentColor" />
-      <circle cx="14" cy="9" r="1.25" fill="currentColor" />
-    </svg>
-  );
-}
-
 function shortAddress(addr: string) {
   return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
-}
-
-function copyText(value: string) {
-  if (typeof navigator !== "undefined" && navigator.clipboard) {
-    navigator.clipboard.writeText(value).catch(() => undefined);
-  }
 }
 
 export default function Portfolio({
@@ -197,6 +160,8 @@ export default function Portfolio({
   if (!isConnected) {
     return (
       <div
+        role="status"
+        aria-live="polite"
         className="rounded-[28px] border px-6 py-16 text-center"
         style={{
           background:
@@ -220,7 +185,7 @@ export default function Portfolio({
           Connect your wallet
         </p>
         <p className="mt-1 text-sm" style={{ color: "var(--arcns-text-muted)" }}>
-          Connect to view your ArcNS portfolio.
+          Connect your wallet from the header to view your ArcNS portfolio.
         </p>
       </div>
     );
@@ -229,6 +194,9 @@ export default function Portfolio({
   if (isLoading) {
     return (
       <div
+        role="status"
+        aria-live="polite"
+        aria-busy="true"
         className="overflow-hidden rounded-[28px] border"
         style={{
           background:
@@ -265,6 +233,8 @@ export default function Portfolio({
   if (error) {
     return (
       <div
+        role="alert"
+        aria-live="assertive"
         className="rounded-[28px] border p-5 text-sm"
         style={{
           background: "rgba(255,92,122,0.08)",
@@ -275,7 +245,7 @@ export default function Portfolio({
         {error}
         <button
           onClick={refetch}
-          className="ml-3 underline"
+          className="arcns-focus-ring ml-3 underline"
           style={{ color: "var(--arcns-danger)" }}
         >
           Retry
@@ -287,6 +257,8 @@ export default function Portfolio({
   if (domains.length === 0) {
     return (
       <div
+        role="status"
+        aria-live="polite"
         className="rounded-[28px] border px-6 py-16 text-center"
         style={{
           background:
@@ -332,7 +304,7 @@ export default function Portfolio({
         </div>
 
         {filteredDomains.length === 0 ? (
-          <div className="px-6 py-12 text-center">
+          <div role="status" aria-live="polite" className="px-6 py-12 text-center">
             <p className="font-semibold" style={{ color: "var(--arcns-text-primary)" }}>
               No matching domains
             </p>
@@ -614,15 +586,11 @@ function DomainRowWithAddr({
           >
             <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-current" />
             <span className="truncate">{shortAddress(receivingAddress)}</span>
-            <button
-              type="button"
-              onClick={() => copyText(receivingAddress)}
-              className="shrink-0 opacity-70 transition-opacity hover:opacity-100"
+            <CopyButton
+              value={receivingAddress}
               aria-label="Copy receiving address"
-              style={{ color: "currentColor" }}
-            >
-              <CopyGlyph />
-            </button>
+              className="arcns-focus-ring h-7 w-7 shrink-0 border-0 p-0"
+            />
           </span>
         ) : addrState === "set" && isStale ? (
           <span
@@ -686,18 +654,6 @@ function DomainRowWithAddr({
           </button>
         ) : null}
 
-        <button
-          type="button"
-          className="flex h-11 w-11 items-center justify-center rounded-[var(--arcns-radius-md)] border transition-colors duration-150"
-          style={{
-            background: "rgba(11,18,36,0.72)",
-            borderColor: "rgba(120,160,255,0.18)",
-            color: "var(--arcns-text-secondary)",
-          }}
-          aria-label={`More actions for ${displayName}`}
-        >
-          <MoreGlyph />
-        </button>
       </div>
     </div>
   );

--- a/frontend/src/components/ui/CopyButton.tsx
+++ b/frontend/src/components/ui/CopyButton.tsx
@@ -50,21 +50,22 @@ export function CopyButton({
   }, [value, copiedDuration]);
 
   return (
-    <button
-      type="button"
-      onClick={handleCopy}
-      aria-label={copied ? "Copied" : ariaLabel}
-      className={cn(
-        "inline-flex items-center justify-center",
-        "w-7 h-7 rounded-[var(--arcns-radius-xs)]",
-        "transition-all duration-150",
-        "text-[var(--arcns-text-muted)] hover:text-[var(--arcns-text-secondary)]",
-        "hover:bg-[rgba(120,160,255,0.08)]",
-        "arcns-focus-ring",
-        className,
-      )}
-    >
-      {copied ? (
+    <>
+      <button
+        type="button"
+        onClick={handleCopy}
+        aria-label={copied ? "Copied" : ariaLabel}
+        className={cn(
+          "inline-flex items-center justify-center",
+          "w-7 h-7 rounded-[var(--arcns-radius-xs)]",
+          "transition-all duration-150",
+          "text-[var(--arcns-text-muted)] hover:text-[var(--arcns-text-secondary)]",
+          "hover:bg-[rgba(120,160,255,0.08)]",
+          "arcns-focus-ring",
+          className,
+        )}
+      >
+        {copied ? (
         /* Checkmark — CSS only */
         <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
           <path d="M2.5 7L5.5 10L11.5 4" stroke="#14F195" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" />
@@ -75,7 +76,11 @@ export function CopyButton({
           <rect x="4.5" y="1.5" width="8" height="8" rx="1.5" stroke="currentColor" strokeWidth="1.25" />
           <path d="M1.5 5.5H3.5V12.5H10.5V10.5" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" />
         </svg>
-      )}
-    </button>
+        )}
+      </button>
+      <span className="sr-only" role="status" aria-live="polite">
+        {copied ? "Copied" : ""}
+      </span>
+    </>
   );
 }


### PR DESCRIPTION
This PR polishes core UI states and accessibility across My Domains, wallet/network status, transaction messaging, and copy feedback.

Included:
- Removes the nonfunctional My Domains Filter control.
- Keeps the portfolio search input and Portfolio/History tabs.
- Improves disconnected, loading, empty, no-match, and error state semantics.
- Adds clearer accessible labels and relationships for My Domains controls.
- Adds alert semantics to wrong-network states.
- Improves wallet-disconnected guidance in register/renew surfaces.
- Clarifies transaction copy between wallet confirmation and submitted/processing states.
- Adds accessible copied feedback through the shared CopyButton.
- Keeps transaction, pricing, ownership, wallet, and contract-call logic unchanged.

Not included:
- No mainnet cutover.
- No contract address additions.
- No discount UI activation.
- No registerWithDiscount enablement.
- No pricing logic changes.
- No contract/write logic changes.
- No deployment script changes.
- No env, secret, wallet, API key, or deployment artifact changes.
- No SEO/internal/audit documents.

Validation:
- Frontend lint passed with existing unrelated warnings.
- Frontend build passed.
- Resolve targeted tests passed: 16/16.
- DomainCard ownership suites passed in isolation: 11/11.
- git diff --check passed.
- Restricted terminology scan passed.
- Full frontend suite still has unrelated pre-existing/concurrency failures outside this PR scope.

Manual QA:
- Home/Search checked.
- DomainCard disconnected state checked.
- My Domains checked.
- Filter control confirmed removed; search input remains.
- Resolve checked and previous truth-state behavior preserved.
- Header wallet/testnet state checked.