### PR TITLE
seo: add metadata and social sharing baseline

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+﻿import type { Metadata } from "next";
 import { Inter, Space_Grotesk } from "next/font/google";
 import "./globals.css";
 import { Providers } from "./providers";
@@ -14,11 +14,29 @@ const spaceGrotesk = Space_Grotesk({
 });
 
 export const metadata: Metadata = {
-  title: "ArcNS — Arc Name Service",
+  title: {
+    default: "ArcNS - Arc Name Services",
+    template: "%s | ArcNS",
+  },
   description:
-    "ArcNS is an independent name service built on Arc Testnet. Register and resolve human-readable .arc and .circle testnet names.",
+    "ArcNS (Arc Name Services) is an independent public testnet app for registering and resolving human-readable .arc and .circle names on Arc Testnet.",
   metadataBase: new URL("https://arcname.services"),
   alternates: { canonical: "/" },
+  openGraph: {
+    type: "website",
+    url: "https://arcname.services/",
+    siteName: "ArcNS",
+    title: "ArcNS - Arc Name Services",
+    description:
+      "Register and resolve .arc and .circle names with ArcNS, an independent public app on Arc Testnet.",
+    locale: "en_US",
+  },
+  twitter: {
+    card: "summary",
+    title: "ArcNS - Arc Name Services",
+    description:
+      "Register and resolve .arc and .circle names with ArcNS on Arc Testnet.",
+  },
   icons: { icon: "/icon.svg" },
 };
 

--- a/frontend/src/app/my-domains/layout.tsx
+++ b/frontend/src/app/my-domains/layout.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "My Domains",
+  description: "Manage your ArcNS wallet portfolio and testnet name records.",
+  alternates: { canonical: "/my-domains" },
+  robots: { index: false, follow: true },
+  openGraph: {
+    type: "website",
+    url: "https://arcname.services/my-domains",
+    title: "My Domains | ArcNS",
+    description: "Manage your ArcNS wallet portfolio and testnet name records.",
+  },
+  twitter: {
+    card: "summary",
+    title: "My Domains | ArcNS",
+    description: "Manage your ArcNS wallet portfolio and testnet name records.",
+  },
+};
+
+export default function MyDomainsLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/frontend/src/app/privacy/page.tsx
+++ b/frontend/src/app/privacy/page.tsx
@@ -5,7 +5,22 @@ import LegalPage, {
   TESTNET_STATUS_NOTICE,
 } from "../../components/LegalPage";
 
-export const metadata: Metadata = { title: "Privacy Policy | ArcNS" };
+export const metadata: Metadata = {
+  title: "Privacy Policy",
+  description: "Privacy information for the independent ArcNS public Arc Testnet app.",
+  alternates: { canonical: "/privacy" },
+  openGraph: {
+    type: "website",
+    url: "https://arcname.services/privacy",
+    title: "Privacy Policy | ArcNS",
+    description: "Privacy information for the independent ArcNS public Arc Testnet app.",
+  },
+  twitter: {
+    card: "summary",
+    title: "Privacy Policy | ArcNS",
+    description: "Privacy information for the independent ArcNS public Arc Testnet app.",
+  },
+};
 
 export default function PrivacyPage() {
   return (

--- a/frontend/src/app/resolve/layout.tsx
+++ b/frontend/src/app/resolve/layout.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Resolve ArcNS Names",
+  description:
+    "Resolve ArcNS .arc and .circle records and inspect name ownership data on Arc Testnet.",
+  alternates: { canonical: "/resolve" },
+  openGraph: {
+    type: "website",
+    url: "https://arcname.services/resolve",
+    title: "Resolve ArcNS Names | ArcNS",
+    description:
+      "Resolve .arc and .circle records with ArcNS on Arc Testnet.",
+  },
+  twitter: {
+    card: "summary",
+    title: "Resolve ArcNS Names | ArcNS",
+    description: "Resolve .arc and .circle records with ArcNS on Arc Testnet.",
+  },
+};
+
+export default function ResolveLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/frontend/src/app/terms/page.tsx
+++ b/frontend/src/app/terms/page.tsx
@@ -6,7 +6,22 @@ import LegalPage, {
   TESTNET_STATUS_NOTICE,
 } from "../../components/LegalPage";
 
-export const metadata: Metadata = { title: "Terms of Use | ArcNS" };
+export const metadata: Metadata = {
+  title: "Terms of Use",
+  description: "Testnet-only terms for using the independent ArcNS public app.",
+  alternates: { canonical: "/terms" },
+  openGraph: {
+    type: "website",
+    url: "https://arcname.services/terms",
+    title: "Terms of Use | ArcNS",
+    description: "Testnet-only terms for using the independent ArcNS public app.",
+  },
+  twitter: {
+    card: "summary",
+    title: "Terms of Use | ArcNS",
+    description: "Testnet-only terms for using the independent ArcNS public app.",
+  },
+};
 
 export default function TermsPage() {
   return (

--- a/frontend/src/app/trademark/page.tsx
+++ b/frontend/src/app/trademark/page.tsx
@@ -5,7 +5,22 @@ import LegalPage, {
   TESTNET_STATUS_NOTICE,
 } from "../../components/LegalPage";
 
-export const metadata: Metadata = { title: "Trademark / Brand Notice | ArcNS" };
+export const metadata: Metadata = {
+  title: "Trademark / Brand Notice",
+  description: "Brand and trademark notice for the independent ArcNS testnet project.",
+  alternates: { canonical: "/trademark" },
+  openGraph: {
+    type: "website",
+    url: "https://arcname.services/trademark",
+    title: "Trademark / Brand Notice | ArcNS",
+    description: "Brand and trademark notice for the independent ArcNS testnet project.",
+  },
+  twitter: {
+    card: "summary",
+    title: "Trademark / Brand Notice | ArcNS",
+    description: "Brand and trademark notice for the independent ArcNS testnet project.",
+  },
+};
 
 export default function TrademarkPage() {
   return (


### PR DESCRIPTION
This PR adds a narrow SEO metadata and social sharing baseline for ArcNS.

Included:
- Improves root metadata in frontend/src/app/layout.tsx.
- Adds testnet-safe title and description copy.
- Adds metadataBase using https://arcname.services.
- Adds root canonical metadata.
- Adds OpenGraph website metadata.
- Adds Twitter/X summary metadata.
- Adds route-specific metadata for /resolve.
- Adds noindex, follow metadata for /my-domains.
- Refines metadata for /terms, /privacy, and /trademark.
- Preserves existing icon handling.
- Uses safe public-testnet wording only.

Route behavior:
- / is indexable with canonical https://arcname.services
- /resolve is indexable with canonical https://arcname.services/resolve
- /my-domains emits noindex, follow
- /terms, /privacy, and /trademark use self-canonicals
- OpenGraph and Twitter metadata are present
- No invented X/Twitter handle was added
- No social preview image was added in this PR

Not included:
- No robots.ts
- No sitemap.ts
- No AI crawler policy
- No SEO strategy document
- No keyword research document
- No internal audit or readiness document
- No mainnet cutover
- No contract address additions
- No discount UI activation
- No registerWithDiscount enablement
- No pricing logic changes
- No contract/write logic changes
- No env, secret, wallet, API key, or deployment artifact changes

Validation:
- Frontend build passed.
- Resolve targeted tests passed: 16/16.
- Metadata HTML output was manually inspected.
- Root title outputs as ArcNS - Arc Name Services.
- /my-domains outputs noindex, follow.
- Canonical URLs were verified for root, Resolve, My Domains, Terms, Privacy, and Trademark.
- git diff --check passed after whitespace cleanup.
- Restricted terminology scan passed.