### PR TITLE
seo: add sitemap and robots baseline

### DIFF
--- a/frontend/src/app/robots.ts
+++ b/frontend/src/app/robots.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: "https://arcname.services/sitemap.xml",
+  };
+}

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -1,0 +1,40 @@
+import type { MetadataRoute } from "next";
+
+const BASE_URL = "https://arcname.services";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date();
+
+  return [
+    {
+      url: `${BASE_URL}/`,
+      lastModified,
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+    {
+      url: `${BASE_URL}/resolve`,
+      lastModified,
+      changeFrequency: "weekly",
+      priority: 0.8,
+    },
+    {
+      url: `${BASE_URL}/terms`,
+      lastModified,
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
+    {
+      url: `${BASE_URL}/privacy`,
+      lastModified,
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
+    {
+      url: `${BASE_URL}/trademark`,
+      lastModified,
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
+  ];
+}


### PR DESCRIPTION
This PR adds a minimal public SEO crawling baseline for ArcNS.

Included:
- Adds frontend/src/app/robots.ts.
- Allows normal crawling for public routes.
- Adds sitemap reference at https://arcname.services/sitemap.xml.
- Adds frontend/src/app/sitemap.ts.
- Includes only public indexable routes:
  - /
  - /resolve
  - /terms
  - /privacy
  - /trademark

Excluded:
- /my-domains, because it is noindex.
- API routes.
- Internal routes.
- Dynamic name URLs.
- Future/mainnet/discount/proof URLs.
- AI crawler-specific policy.
- SEO strategy docs.
- Internal audit/readiness docs.

Validation:
- Frontend build passed.
- /robots.txt route exists.
- /sitemap.xml route exists.
- Local route inspection passed.
- Sitemap contains only the five approved URLs.
- /my-domains is not included.
- git diff --check passed.
- Restricted terminology scan passed.