### PR TITLE
seo: add answer-engine crawler allow rules

### DIFF
--- a/frontend/src/app/robots.ts
+++ b/frontend/src/app/robots.ts
@@ -2,10 +2,28 @@ import type { MetadataRoute } from "next";
 
 export default function robots(): MetadataRoute.Robots {
   return {
-    rules: {
-      userAgent: "*",
-      allow: "/",
-    },
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+      },
+      {
+        userAgent: "OAI-SearchBot",
+        allow: "/",
+      },
+      {
+        userAgent: "PerplexityBot",
+        allow: "/",
+      },
+      {
+        userAgent: "Googlebot",
+        allow: "/",
+      },
+      {
+        userAgent: "Bingbot",
+        allow: "/",
+      },
+    ],
     sitemap: "https://arcname.services/sitemap.xml",
   };
 }


### PR DESCRIPTION
This PR adds a conservative answer-engine crawler allow baseline to robots.txt.

Included:
- Updates frontend/src/app/robots.ts only.
- Preserves the wildcard rule:
  - User-agent: *
  - Allow: /
- Preserves sitemap reference:
  - https://arcname.services/sitemap.xml
- Adds explicit allow rules for:
  - OAI-SearchBot
  - PerplexityBot
  - Googlebot
  - Bingbot

Not included:
- No Disallow rules.
- No GPTBot rule.
- No Google-Extended rule.
- No OAI-AdsBot rule.
- No Perplexity-User rule.
- No ClaudeBot rule.
- No sitemap changes.
- No SEO strategy docs.
- No internal audit/readiness docs.
- No mainnet cutover.
- No contract address changes.
- No pricing, wallet, contract, or write logic changes.

Behavior:
- Public routes remain crawlable.
- /my-domains remains handled by page-level noindex, follow metadata.
- Sitemap remains https://arcname.services/sitemap.xml.
- This PR does not make ranking or AI visibility guarantees.

Validation:
- Frontend build passed.
- Generated robots output was inspected.
- Required user agents are present.
- GPTBot, Google-Extended, OAI-AdsBot, Perplexity-User, ClaudeBot, and Disallow are absent.
- frontend/next-env.d.ts was restored after build.
- git diff --check passed.
- Restricted terminology scan passed.