### PR TITLE
fix: improve image accessibility alt text

### DIFF
--- a/frontend/src/app/my-domains/page.tsx
+++ b/frontend/src/app/my-domains/page.tsx
@@ -32,14 +32,15 @@ export default function MyDomainsPage() {
       <main className="arcns-domains-shell">
         <section className="arcns-domains-hero">
           <div className="arcns-domains-emblem" aria-hidden="true">
-  <Image
-    src="/arcns/arcns-emblem.svg"
-    alt=""
-    width={132}
-    height={132}
-    priority
-  />
-</div>
+            <Image
+              src="/arcns/arcns-emblem.svg"
+              alt=""
+              aria-hidden="true"
+              width={132}
+              height={132}
+              priority
+            />
+          </div>
 
           <div className="arcns-domains-title">
             <div className="arcns-domains-title-row">

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -113,6 +113,7 @@ export default function HomePage() {
             <Image
               src="/arcns/arcns-emblem.svg"
               alt=""
+              aria-hidden="true"
               width={520}
               height={520}
               priority

--- a/frontend/src/app/resolve/page.tsx
+++ b/frontend/src/app/resolve/page.tsx
@@ -585,6 +585,7 @@ export default function ResolvePage() {
             <Image
               src="/arcns/arcns-emblem.svg"
               alt=""
+              aria-hidden="true"
               width={250}
               height={250}
               priority
@@ -710,7 +711,13 @@ export default function ResolvePage() {
               }}
               aria-hidden="true"
             >
-              <Image src="/arcns/arcns-emblem.svg" alt="" width={40} height={40} />
+              <Image
+                src="/arcns/arcns-emblem.svg"
+                alt=""
+                aria-hidden="true"
+                width={40}
+                height={40}
+              />
             </div>
             <h2
               className="text-2xl font-bold"

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -163,6 +163,7 @@ export default function Header() {
             <Image
               src="/arcns/arcns-emblem.svg"
               alt=""
+              aria-hidden="true"
               width={28}
               height={28}
               priority


### PR DESCRIPTION
This PR improves image accessibility and addresses the Bing SEO/GEO notice about missing image alt attributes.

Included:
- Updates image alt handling on:
  - Home
  - Resolve
  - My Domains
  - Header
- Decorative ArcNS emblem images now explicitly use alt="" with aria-hidden="true".
- Meaningful footer emblem alt text is preserved as "ArcNS emblem".
- Preserves existing visual design and layout.

Not included:
- No metadata changes.
- No robots.txt changes.
- No sitemap changes.
- No structured data.
- No SEO strategy docs.
- No internal audit/readiness docs.
- No mainnet cutover.
- No contract address changes.
- No pricing, wallet, contract, or write logic changes.
- No environment changes.

Validation:
- Frontend build passed.
- ResolvePage targeted tests passed: 16/16.
- Local production route smoke check passed for:
  - /
  - /resolve
  - /my-domains
  - /terms
  - /privacy
  - /trademark
- Server-rendered image audit found zero images missing an alt attribute on inspected routes.
- frontend/next-env.d.ts was restored after build.
- git diff --check passed.
- Restricted terminology scan passed.