### PR TITLE
seo: add structured data baseline

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback } from "react";
 import Image from "next/image";
 import SearchBar from "../components/SearchBar";
 import DomainCard from "../components/DomainCard";
+import { JsonLd } from "../components/JsonLd";
 import {
   isValidLabel,
   PRICING_TABLE,
@@ -84,6 +85,16 @@ const FEATURES = [
   },
 ] as const;
 
+const websiteJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "@id": "https://arcname.services/#website",
+  name: "ArcNS",
+  alternateName: "Arc Name Services",
+  url: "https://arcname.services/",
+  description: "Human-readable .arc and .circle names on Arc Testnet.",
+};
+
 export default function HomePage() {
   const [pending, setPending] = useState<{ label: string; tld: SupportedTLD } | null>(null);
   const [committed, setCommitted] = useState<{ label: string; tld: SupportedTLD } | null>(null);
@@ -104,6 +115,7 @@ export default function HomePage() {
 
   return (
     <div className="arcns-landing-page">
+      <JsonLd data={websiteJsonLd} />
       <section className="arcns-landing-scene">
         <div className="arcns-landing-bg" aria-hidden="true" />
         <div className="arcns-orbit-lines" aria-hidden="true" />

--- a/frontend/src/app/resolve/page.tsx
+++ b/frontend/src/app/resolve/page.tsx
@@ -44,9 +44,22 @@ import { isValidLabel } from "../../lib/domain";
 import { CopyButton } from "../../components/ui/CopyButton";
 import { TldBadge } from "../../components/ui/TldBadge";
 import { FooterIdentityLine } from "../../components/ui/FooterIdentityLine";
+import { JsonLd } from "../../components/JsonLd";
 
 export type ResolveQuery = { label: string; tld: SupportedTLD; domain: string };
 export type ResolveInputState = "pristine" | "invalid" | "malformed" | "unsupportedTld" | "valid";
+
+const resolvePageJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "@id": "https://arcname.services/resolve#webpage",
+  name: "ArcNS Resolve",
+  url: "https://arcname.services/resolve",
+  description: "Inspect ArcNS names and on-chain identity records on Arc Testnet.",
+  isPartOf: {
+    "@id": "https://arcname.services/#website",
+  },
+};
 
 /** Resolve accepts exactly one ASCII label plus one supported suffix. */
 export function parseResolveQuery(raw: string): ResolveQuery | { error: Exclude<ResolveInputState, "pristine" | "valid"> } {
@@ -565,6 +578,7 @@ export default function ResolvePage() {
           "radial-gradient(circle at 10% 12%, rgba(37,99,255,0.16), transparent 28%), radial-gradient(circle at 88% 10%, rgba(0,212,255,0.10), transparent 34%), linear-gradient(180deg, #050A18 0%, #071026 46%, #050A18 100%)",
       }}
     >
+      <JsonLd data={resolvePageJsonLd} />
       <div
         className="pointer-events-none absolute inset-0"
         aria-hidden="true"

--- a/frontend/src/components/JsonLd.tsx
+++ b/frontend/src/components/JsonLd.tsx
@@ -1,0 +1,14 @@
+type JsonLdProps = {
+  data: Record<string, unknown>;
+};
+
+export function JsonLd({ data }: JsonLdProps) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify(data).replace(/</g, "\\u003c"),
+      }}
+    />
+  );
+}


### PR DESCRIPTION
This PR adds a minimal, conservative JSON-LD structured data baseline for ArcNS.

Included:
- Adds a reusable JsonLd component.
- Adds WebSite JSON-LD to the Home page.
- Adds WebPage JSON-LD to the Resolve page.
- Uses stable canonical URLs:
  - https://arcname.services/
  - https://arcname.services/resolve
- Keeps all wording Arc Testnet-safe and conservative.
- Does not add markup to /my-domains because it is user-specific and noindex.
- Does not add markup to legal pages in this baseline PR.

Not included:
- No WebApplication schema.
- No Organization schema.
- No FAQPage or HowTo schema.
- No ratings, reviews, offers, prices, sameAs, founder, employee, funding, or grant fields.
- No official endorsement claims.
- No mainnet-live claims.
- No metadata changes.
- No robots.txt changes.
- No sitemap changes.
- No wallet, contract, pricing, or environment changes.
- No visual UI changes.
- No public SEO strategy docs or internal readiness docs.

Validation:
- ResolvePage tests passed: 16/16.
- Frontend build passed.
- Generated HTML inspected:
  - / has one WebSite JSON-LD block.
  - /resolve has one WebPage JSON-LD block.
  - /my-domains, /terms, /privacy, and /trademark have no JSON-LD.
- JSON-LD parsed successfully.
- frontend/next-env.d.ts restored and has no final diff.
- git diff --check passed.
- Restricted-content scan passed.
- Unsupported structured-data field/claim scan passed.