### PR TITLE
chore(frontend): normalize network wording

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -12,6 +12,7 @@ import {
   type SupportedTLD,
 } from "../lib/normalization";
 import { ACTIVE_CHAIN_ID } from "../lib/chainConfig";
+import { NETWORK_DISPLAY } from "../lib/networkDisplay";
 
 const DISPLAY_PRICING_TABLE = ACTIVE_CHAIN_ID === 5042
   ? MAINNET_PRICING.map((row) => ({ len: row.label, price: `${row.display.replace("/yr", "")} / year`, annual: row.annualUSDC }))
@@ -19,8 +20,8 @@ const DISPLAY_PRICING_TABLE = ACTIVE_CHAIN_ID === 5042
 
 const TRUST_ITEMS = [
   {
-    title: "Arc Testnet",
-    sub: "Chain ID 5042002",
+    title: NETWORK_DISPLAY.networkDisplayName,
+    sub: NETWORK_DISPLAY.chainIdLabel,
     accent: "var(--arcns-cyan)",
     icon: (
       <svg viewBox="0 0 28 28" fill="none" aria-hidden="true">
@@ -31,7 +32,7 @@ const TRUST_ITEMS = [
   },
   {
     title: "Pay with USDC",
-    sub: "Testnet USDC. On-chain.",
+    sub: `${NETWORK_DISPLAY.currencyDisplayName}. On-chain.`,
     accent: "#3BA3FF",
     icon: (
       <svg viewBox="0 0 28 28" fill="none" aria-hidden="true">
@@ -92,7 +93,7 @@ const websiteJsonLd = {
   name: "ArcNS",
   alternateName: "Arc Name Services",
   url: "https://arcname.services/",
-  description: "Human-readable .arc and .circle names on Arc Testnet.",
+  description: "Human-readable .arc and .circle names on Arc.",
 };
 
 export default function HomePage() {
@@ -136,11 +137,11 @@ export default function HomePage() {
           <div className="arcns-hero-copy">
             <div className="arcns-live-badge">
               <span className="arcns-pulse-dot" aria-hidden="true" />
-              Live on Arc Testnet · Chain ID 5042002
+              Live on {NETWORK_DISPLAY.networkDisplayName} · {NETWORK_DISPLAY.chainIdLabel}
             </div>
 
             <h1 className="arcns-hero-headline">
-              Human-readable names <span className="arcns-gradient-text">on Arc Testnet</span>
+              Human-readable names <span className="arcns-gradient-text">on Arc</span>
             </h1>
 
             <p className="arcns-hero-subtitle">
@@ -150,8 +151,8 @@ export default function HomePage() {
               Receive an ERC-721 name NFT for your selected registration period.
             </p>
             <p className="arcns-hero-disclaimer">
-              Independent Arc Testnet app. <strong>.circle</strong> is an ArcNS testnet namespace; no Circle
-              affiliation or endorsement is implied.
+              Independent ArcNS app for <strong>.arc</strong> and <strong>.circle</strong> names. Current network:{" "}
+              {NETWORK_DISPLAY.networkDisplayName}. No Circle affiliation or endorsement is implied.
             </p>
           </div>
 

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
+import { NETWORK_DISPLAY } from "../lib/networkDisplay";
 
 type FooterLinkItem = {
   label: string;
@@ -192,7 +193,7 @@ export default function Footer() {
                     ArcNS
                   </p>
                   <p className="text-sm text-[var(--arcns-text-secondary)]">
-                    Human-readable names for Arc Testnet addresses.
+                    Human-readable names for addresses on Arc.
                   </p>
                 </div>
               </div>
@@ -204,7 +205,9 @@ export default function Footer() {
               </div>
 
               <div className="space-y-2 text-sm leading-6 text-[var(--arcns-text-secondary)]">
-                <p>Live on Arc Testnet · Pre-mainnet · External audit pending</p>
+                <p>
+                  Live on {NETWORK_DISPLAY.networkDisplayName} · {NETWORK_DISPLAY.environmentStatusLabel} · External audit pending
+                </p>
                 <p className="max-w-xl text-[13px] text-[var(--arcns-text-muted)]">
                   ArcNS is an independent name service built on Arc Testnet. ArcNS is not affiliated with,
                   endorsed by, or sponsored by Circle unless separately agreed in writing.

--- a/frontend/src/components/ui/FooterIdentityLine.tsx
+++ b/frontend/src/components/ui/FooterIdentityLine.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from "react";
+import { NETWORK_DISPLAY } from "../../lib/networkDisplay";
 import { cn } from "./utils";
 
 interface FooterIdentityLineProps {
@@ -29,7 +30,9 @@ export function FooterIdentityLine({ className }: FooterIdentityLineProps) {
         {" · "}
         Identity for everything on Arc
         {" · "}
-        <span className="font-mono text-xs">Arc Testnet · Chain ID 5042002</span>
+        <span className="font-mono text-xs">
+          {NETWORK_DISPLAY.networkDisplayName} · {NETWORK_DISPLAY.chainIdLabel}
+        </span>
       </p>
     </footer>
   );

--- a/frontend/src/components/ui/NetworkBadge.tsx
+++ b/frontend/src/components/ui/NetworkBadge.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from "react";
+import { NETWORK_DISPLAY } from "../../lib/networkDisplay";
 import { cn } from "./utils";
 
 export type NetworkVariant = "testnet" | "wrong-network";
@@ -19,7 +20,7 @@ interface NetworkBadgeProps {
 
 const variantConfig: Record<NetworkVariant, { label: string; style: React.CSSProperties }> = {
   testnet: {
-    label: "Arc Testnet",
+    label: NETWORK_DISPLAY.networkDisplayName,
     style: {
       background: "rgba(120, 160, 255, 0.10)",
       border: "1px solid rgba(120, 160, 255, 0.20)",

--- a/frontend/src/lib/networkDisplay.ts
+++ b/frontend/src/lib/networkDisplay.ts
@@ -1,0 +1,13 @@
+/**
+ * Display-only labels for the current public ArcNS environment.
+ *
+ * These values must not be used to configure wallets, RPCs, contracts,
+ * transaction flows, or any other runtime network behavior.
+ */
+export const NETWORK_DISPLAY = {
+  networkDisplayName: "Arc Testnet",
+  networkShortLabel: "Testnet",
+  chainIdLabel: "Chain ID 5042002",
+  currencyDisplayName: "Testnet USDC",
+  environmentStatusLabel: "Pre-mainnet",
+} as const;


### PR DESCRIPTION
## Summary

- Changes broad hero/marketing wording from “Arc Testnet” to generic “Arc” product positioning.
- Keeps truthful current-network disclosure visible as Arc Testnet / Chain ID 5042002 / Pre-mainnet.
- Adds a display-only `NETWORK_DISPLAY` helper for frontend network/status labels.

## Safety

- This is not a mainnet cutover.
- No runtime network behavior changed.
- No chain ID, RPC, contract address, USDC address, wallet, pricing, hook, deploy, or transaction logic changed.
- No mainnet-live, official, endorsement, discount, or proof-activation claim was introduced.
- Current app still clearly identifies the active environment as Arc Testnet.

## Validation

- `git diff --check`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`
- Forbidden-file restricted scan
- Risky text scan